### PR TITLE
[F-01] Mobile Audio Unlock + Audio Cache

### DIFF
--- a/src/audio/audioCache.ts
+++ b/src/audio/audioCache.ts
@@ -1,0 +1,170 @@
+import type { AudioAsset } from "./elevenlabs";
+
+type ProgressHandler = (loaded: number, total: number) => void;
+
+interface AudioCacheOptions {
+  skipAudio?: boolean;
+}
+
+type BrowserWindowWithWebkitAudio = Window & {
+  webkitAudioContext?: typeof AudioContext;
+};
+
+export class AudioCache {
+  private readonly assets: AudioAsset[];
+  private readonly skipAudio: boolean;
+  private readonly elements = new Map<string, HTMLAudioElement>();
+  private readonly loadedIds = new Set<string>();
+  private unlocked = false;
+  private audioContext?: AudioContext;
+
+  constructor(assets: AudioAsset[], options: AudioCacheOptions = {}) {
+    this.assets = assets;
+    this.skipAudio = options.skipAudio ?? false;
+  }
+
+  async load(onProgress?: ProgressHandler): Promise<void> {
+    const total = this.assets.length;
+
+    if (total === 0) {
+      onProgress?.(1, 1);
+      return;
+    }
+
+    let loaded = 0;
+    const markLoaded = (id: string): void => {
+      this.loadedIds.add(id);
+      loaded += 1;
+      onProgress?.(loaded, total);
+    };
+
+    for (const asset of this.assets) {
+      if (this.skipAudio) {
+        markLoaded(asset.id);
+        continue;
+      }
+
+      await this.loadElement(asset);
+      markLoaded(asset.id);
+    }
+  }
+
+  async unlock(): Promise<void> {
+    if (this.unlocked) {
+      return;
+    }
+
+    const audioWindow = window as BrowserWindowWithWebkitAudio;
+    const AudioContextConstructor = window.AudioContext ?? audioWindow.webkitAudioContext;
+
+    if (AudioContextConstructor) {
+      this.audioContext = new AudioContextConstructor();
+      await this.audioContext.resume();
+
+      const buffer = this.audioContext.createBuffer(1, 1, 22050);
+      const source = this.audioContext.createBufferSource();
+      source.buffer = buffer;
+      source.connect(this.audioContext.destination);
+      source.start(0);
+    }
+
+    this.unlocked = true;
+  }
+
+  isUnlocked(): boolean {
+    return this.unlocked;
+  }
+
+  getProgress(): number {
+    if (this.assets.length === 0) {
+      return 1;
+    }
+
+    return this.loadedIds.size / this.assets.length;
+  }
+
+  play(id: string): boolean {
+    if (!this.unlocked || !this.loadedIds.has(id)) {
+      return false;
+    }
+
+    if (this.skipAudio) {
+      return true;
+    }
+
+    const element = this.elements.get(id);
+    if (!element) {
+      return false;
+    }
+
+    element.currentTime = 0;
+    void element.play();
+    return true;
+  }
+
+  stop(id: string): void {
+    const element = this.elements.get(id);
+
+    if (!element) {
+      return;
+    }
+
+    element.pause();
+    element.currentTime = 0;
+  }
+
+  crossfade(fromId: string, toId: string, durationMs: number): boolean {
+    const from = this.elements.get(fromId);
+    const to = this.elements.get(toId);
+
+    if (this.skipAudio) {
+      return this.play(toId);
+    }
+
+    if (!from || !to || !this.unlocked) {
+      return false;
+    }
+
+    const targetVolume = to.volume;
+    const startedAt = performance.now();
+    to.volume = 0;
+    void to.play();
+
+    const step = (now: number): void => {
+      const progress = Math.min(1, (now - startedAt) / Math.max(1, durationMs));
+      from.volume = from.volume * (1 - progress);
+      to.volume = targetVolume * progress;
+
+      if (progress < 1) {
+        requestAnimationFrame(step);
+        return;
+      }
+
+      from.pause();
+      from.currentTime = 0;
+    };
+
+    requestAnimationFrame(step);
+    return true;
+  }
+
+  private loadElement(asset: AudioAsset): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const element = new Audio(asset.src);
+      element.preload = "auto";
+      element.volume = asset.volume;
+      element.loop = asset.loop ?? false;
+
+      element.addEventListener("canplaythrough", () => {
+        this.elements.set(asset.id, element);
+        resolve();
+      }, { once: true });
+
+      element.addEventListener("error", () => {
+        reject(new Error(`Failed to load audio asset: ${asset.id}`));
+      }, { once: true });
+
+      element.load();
+    });
+  }
+}

--- a/src/audio/elevenlabs.ts
+++ b/src/audio/elevenlabs.ts
@@ -1,0 +1,33 @@
+export type AudioAssetType = "dialogue" | "music" | "sfx";
+
+export interface AudioAsset {
+  id: string;
+  type: AudioAssetType;
+  src: string;
+  volume: number;
+  loop?: boolean;
+}
+
+export const AUDIO_MANIFEST: AudioAsset[] = [
+  {
+    id: "dialogue_test",
+    type: "dialogue",
+    src: "/audio/dialogue_test.mp3",
+    volume: 1
+  },
+  {
+    id: "music_menu",
+    type: "music",
+    src: "/audio/music_menu.mp3",
+    volume: 0.15,
+    loop: true
+  },
+  {
+    id: "sfx_card_play",
+    type: "sfx",
+    src: "/audio/sfx_card_play.mp3",
+    volume: 0.6
+  }
+];
+
+export const getAudioManifest = (): AudioAsset[] => AUDIO_MANIFEST;

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,7 @@
 export const GAME_TITLE = "DORA: The Compliance Roguelike";
 export const TOTAL_ROUNDS = 15;
 export const DEV_MODE = import.meta.env.DEV;
+export const DEBUG_SKIP_AUDIO = import.meta.env.VITE_DEBUG_SKIP_AUDIO !== "false";
 
 export const COLORS = {
   background: "#0d0d1a",

--- a/src/game/GameState.ts
+++ b/src/game/GameState.ts
@@ -12,6 +12,7 @@ export type Phase =
 export class GameState {
   private phase: Phase;
   private elapsedSeconds = 0;
+  private loadingProgress = 0;
 
   constructor(initialPhase: Phase = "LOADING") {
     this.phase = initialPhase;
@@ -32,5 +33,13 @@ export class GameState {
 
   getElapsedSeconds(): number {
     return this.elapsedSeconds;
+  }
+
+  setLoadingProgress(progress: number): void {
+    this.loadingProgress = Math.min(1, Math.max(0, progress));
+  }
+
+  getLoadingProgress(): number {
+    return this.loadingProgress;
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,9 @@
-import { COLORS, DEV_MODE, GAME_TITLE, TOTAL_ROUNDS } from "./config";
+import { AudioCache } from "./audio/audioCache";
+import { getAudioManifest } from "./audio/elevenlabs";
+import { COLORS, DEBUG_SKIP_AUDIO, DEV_MODE, GAME_TITLE, TOTAL_ROUNDS } from "./config";
 import { GameState, type Phase } from "./game/GameState";
+import { renderLoadingScene } from "./scenes/LoadingScene";
+import { renderMenuScene } from "./scenes/MenuScene";
 
 const canvas = document.querySelector<HTMLCanvasElement>("#game");
 
@@ -14,6 +18,7 @@ if (!context) {
 }
 
 const gameState = new GameState("LOADING");
+const audioCache = new AudioCache(getAudioManifest(), { skipAudio: DEBUG_SKIP_AUDIO });
 
 let lastFrameTime = performance.now();
 let devicePixelRatioCache = window.devicePixelRatio || 1;
@@ -56,6 +61,16 @@ const render = (): void => {
   const width = window.innerWidth;
   const height = window.innerHeight;
   const phase = gameState.getPhase();
+
+  if (phase === "LOADING" || phase === "TAP_TO_START") {
+    renderLoadingScene(context, width, height, gameState.getLoadingProgress(), phase === "TAP_TO_START");
+    return;
+  }
+
+  if (phase === "MENU") {
+    renderMenuScene(context, width, height);
+    return;
+  }
 
   context.fillStyle = COLORS.background;
   context.fillRect(0, 0, width, height);
@@ -103,6 +118,16 @@ const loop = (frameTime: number): void => {
 };
 
 window.addEventListener("resize", resizeCanvas);
+canvas.addEventListener("click", () => {
+  if (gameState.getPhase() !== "TAP_TO_START") {
+    return;
+  }
+
+  void audioCache.unlock().then(() => {
+    gameState.setPhase("MENU");
+    audioCache.play("music_menu");
+  });
+});
 
 if (DEV_MODE) {
   window.addEventListener("keydown", (event) => {
@@ -122,8 +147,27 @@ if (DEV_MODE) {
     if (nextPhase) {
       gameState.setPhase(nextPhase);
     }
+
+    if (event.key.toLowerCase() === "d") {
+      audioCache.play("dialogue_test");
+    }
+
+    if (event.key.toLowerCase() === "m") {
+      audioCache.play("music_menu");
+    }
+
+    if (event.key.toLowerCase() === "s") {
+      audioCache.play("sfx_card_play");
+    }
   });
 }
 
 resizeCanvas();
+void audioCache.load((loaded, total) => {
+  gameState.setLoadingProgress(loaded / total);
+
+  if (loaded === total) {
+    gameState.setPhase("TAP_TO_START");
+  }
+});
 requestAnimationFrame(loop);

--- a/src/scenes/LoadingScene.ts
+++ b/src/scenes/LoadingScene.ts
@@ -1,0 +1,40 @@
+import { COLORS, GAME_TITLE } from "../config";
+
+export const renderLoadingScene = (
+  context: CanvasRenderingContext2D,
+  width: number,
+  height: number,
+  progress: number,
+  readyForTap: boolean
+): void => {
+  context.fillStyle = COLORS.background;
+  context.fillRect(0, 0, width, height);
+
+  context.fillStyle = COLORS.text;
+  context.font = "700 28px system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif";
+  context.textAlign = "center";
+  context.textBaseline = "middle";
+  context.fillText(GAME_TITLE, width / 2, height * 0.34, Math.max(260, width - 48));
+
+  context.fillStyle = COLORS.muted;
+  context.font = "16px system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif";
+  context.fillText("The Regulator is reviewing your compliance records...", width / 2, height * 0.43, Math.max(260, width - 48));
+
+  const barWidth = Math.min(420, width - 48);
+  const barHeight = 12;
+  const barX = (width - barWidth) / 2;
+  const barY = height * 0.5;
+
+  context.fillStyle = COLORS.surface;
+  context.fillRect(barX, barY, barWidth, barHeight);
+  context.fillStyle = COLORS.euBlue;
+  context.fillRect(barX, barY, barWidth * progress, barHeight);
+
+  context.fillStyle = readyForTap ? COLORS.text : COLORS.muted;
+  context.font = "700 18px system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif";
+  context.fillText(
+    readyForTap ? "[ Tap anywhere to begin your audit ]" : `${Math.round(progress * 100)}% loaded`,
+    width / 2,
+    height * 0.6
+  );
+};

--- a/src/scenes/MenuScene.ts
+++ b/src/scenes/MenuScene.ts
@@ -1,0 +1,24 @@
+import { COLORS, GAME_TITLE } from "../config";
+
+export const renderMenuScene = (
+  context: CanvasRenderingContext2D,
+  width: number,
+  height: number
+): void => {
+  context.fillStyle = COLORS.background;
+  context.fillRect(0, 0, width, height);
+
+  context.fillStyle = COLORS.text;
+  context.font = "700 32px system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif";
+  context.textAlign = "center";
+  context.textBaseline = "middle";
+  context.fillText(GAME_TITLE, width / 2, height * 0.36, Math.max(260, width - 48));
+
+  context.fillStyle = COLORS.euBlue;
+  context.font = "700 20px system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif";
+  context.fillText("Audio unlocked. Awaiting the audit.", width / 2, height * 0.48, Math.max(260, width - 48));
+
+  context.fillStyle = COLORS.muted;
+  context.font = "14px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace";
+  context.fillText("Dev keys: D dialogue, M music, S sfx", width / 2, height * 0.58, Math.max(260, width - 48));
+};

--- a/tests/AudioCache.test.ts
+++ b/tests/AudioCache.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AudioCache } from "../src/audio/audioCache";
+import type { AudioAsset } from "../src/audio/elevenlabs";
+
+const assets: AudioAsset[] = [
+  { id: "dialogue_test", type: "dialogue", src: "/audio/dialogue_test.mp3", volume: 1 },
+  { id: "music_menu", type: "music", src: "/audio/music_menu.mp3", volume: 0.15, loop: true },
+  { id: "sfx_card_play", type: "sfx", src: "/audio/sfx_card_play.mp3", volume: 0.6 }
+];
+
+describe("AudioCache", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("reports progress while loading in skip-audio mode", async () => {
+    const cache = new AudioCache(assets, { skipAudio: true });
+    const progress: number[] = [];
+
+    await cache.load((loaded, total) => {
+      progress.push(loaded / total);
+    });
+
+    expect(cache.getProgress()).toBe(1);
+    expect(progress).toEqual([1 / 3, 2 / 3, 1]);
+  });
+
+  it("will not play before browser audio is unlocked", async () => {
+    const cache = new AudioCache(assets, { skipAudio: true });
+
+    await cache.load();
+
+    expect(cache.play("music_menu")).toBe(false);
+  });
+
+  it("plays loaded assets after audio is unlocked", async () => {
+    class FakeAudioContext {
+      destination = {};
+
+      async resume(): Promise<void> {
+        return Promise.resolve();
+      }
+
+      createBuffer(): AudioBuffer {
+        return {} as AudioBuffer;
+      }
+
+      createBufferSource(): AudioBufferSourceNode {
+        return {
+          buffer: null,
+          connect: vi.fn(),
+          start: vi.fn()
+        } as unknown as AudioBufferSourceNode;
+      }
+    }
+
+    vi.stubGlobal("window", { AudioContext: FakeAudioContext });
+    const cache = new AudioCache(assets, { skipAudio: true });
+
+    await cache.load();
+    await cache.unlock();
+
+    expect(cache.isUnlocked()).toBe(true);
+    expect(cache.play("music_menu")).toBe(true);
+  });
+
+  it("treats an empty manifest as fully loaded", async () => {
+    const cache = new AudioCache([], { skipAudio: true });
+
+    await cache.load();
+
+    expect(cache.getProgress()).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Adds the mobile-safe audio loading checkpoint: manifest-driven cache, debug skip-audio mode, loading progress, tap-to-start unlock, and a simple menu after audio unlock.

## What Changed

- Added `AudioCache` with `load`, `unlock`, `play`, `stop`, and `crossfade`.
- Added placeholder ElevenLabs audio manifest for dialogue, menu music, and card SFX.
- Added `DEBUG_SKIP_AUDIO` so development can proceed before generated assets exist.
- Added loading and menu scenes.
- Wired click/tap unlock into the main canvas flow.
- Added dev keys to exercise dialogue, music, and SFX play calls.
- Added focused AudioCache unit tests.

## Validation

- `npm test`
- `npm run build`
- `npx playwright screenshot --browser=chromium --channel=chrome --viewport-size=390,844 http://localhost:5181/index.html /tmp/dora-feature1-loading.png`
- In-app browser tap path ran without console errors.

## Screenshots

Mobile loading/tap prompt screenshot captured locally at `/tmp/dora-feature1-loading.png`.

Closes #3