### PR TITLE
[F-02] Compliance Board

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -3,10 +3,21 @@ export const TOTAL_ROUNDS = 15;
 export const DEV_MODE = import.meta.env.DEV;
 export const DEBUG_SKIP_AUDIO = import.meta.env.VITE_DEBUG_SKIP_AUDIO !== "false";
 
+export const INDICATORS = [
+  "ictrisk",
+  "incidents",
+  "thirdparty",
+  "testing",
+  "reporting"
+] as const;
+
 export const COLORS = {
   background: "#0d0d1a",
   surface: "#1a1a2e",
   euBlue: "#4a90e2",
+  dangerRed: "#c0392b",
+  safeGreen: "#27ae60",
+  warnAmber: "#e67e22",
   text: "#ecf0f1",
   muted: "#8fa3b8"
 } as const;

--- a/src/game/ComplianceBoard.ts
+++ b/src/game/ComplianceBoard.ts
@@ -1,0 +1,90 @@
+import { INDICATORS } from "../config";
+
+export type Indicator = typeof INDICATORS[number];
+
+export interface IndicatorState {
+  id: Indicator;
+  label: string;
+  value: number;
+  lastChangedAt: number;
+}
+
+export interface DamageTarget {
+  indicator: Indicator;
+  amount: number;
+}
+
+const LABELS: Record<Indicator, string> = {
+  ictrisk: "ICT Risk",
+  incidents: "Incidents",
+  thirdparty: "Third-Party",
+  testing: "Testing",
+  reporting: "Reporting"
+};
+
+export class ComplianceBoard {
+  private readonly indicators = new Map<Indicator, IndicatorState>();
+
+  constructor() {
+    for (const indicator of INDICATORS) {
+      this.indicators.set(indicator, {
+        id: indicator,
+        label: LABELS[indicator],
+        value: 100,
+        lastChangedAt: 0
+      });
+    }
+  }
+
+  getAll(): IndicatorState[] {
+    return INDICATORS.map((indicator) => ({ ...this.requireIndicator(indicator) }));
+  }
+
+  getValue(indicator: Indicator): number {
+    return this.requireIndicator(indicator).value;
+  }
+
+  damage(indicator: Indicator, amount: number, changedAt = performance.now()): number {
+    const state = this.requireIndicator(indicator);
+    state.value = this.clamp(state.value - Math.max(0, amount));
+    state.lastChangedAt = changedAt;
+    return state.value;
+  }
+
+  restore(indicator: Indicator, amount: number, changedAt = performance.now()): number {
+    const state = this.requireIndicator(indicator);
+    state.value = this.clamp(state.value + Math.max(0, amount));
+    state.lastChangedAt = changedAt;
+    return state.value;
+  }
+
+  damageMany(targets: DamageTarget[], changedAt = performance.now()): void {
+    for (const target of targets) {
+      this.damage(target.indicator, target.amount, changedAt);
+    }
+  }
+
+  getLowest(): IndicatorState {
+    return this.getAll().reduce((lowest, current) => (
+      current.value < lowest.value ? current : lowest
+    ));
+  }
+
+  isFailed(): boolean {
+    return this.getAll().some((indicator) => indicator.value <= 0);
+  }
+
+  private requireIndicator(indicator: Indicator): IndicatorState {
+    const state = this.indicators.get(indicator);
+
+    if (!state) {
+      throw new Error(`Unknown compliance indicator: ${indicator}`);
+    }
+
+    return state;
+  }
+
+  private clamp(value: number): number {
+    return Math.min(100, Math.max(0, Math.round(value)));
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,9 +1,11 @@
 import { AudioCache } from "./audio/audioCache";
 import { getAudioManifest } from "./audio/elevenlabs";
-import { COLORS, DEBUG_SKIP_AUDIO, DEV_MODE, GAME_TITLE, TOTAL_ROUNDS } from "./config";
+import { COLORS, DEBUG_SKIP_AUDIO, DEV_MODE, GAME_TITLE, INDICATORS, TOTAL_ROUNDS } from "./config";
+import { ComplianceBoard } from "./game/ComplianceBoard";
 import { GameState, type Phase } from "./game/GameState";
 import { renderLoadingScene } from "./scenes/LoadingScene";
 import { renderMenuScene } from "./scenes/MenuScene";
+import { renderComplianceBoard } from "./ui/BoardRenderer";
 
 const canvas = document.querySelector<HTMLCanvasElement>("#game");
 
@@ -19,6 +21,7 @@ if (!context) {
 
 const gameState = new GameState("LOADING");
 const audioCache = new AudioCache(getAudioManifest(), { skipAudio: DEBUG_SKIP_AUDIO });
+const complianceBoard = new ComplianceBoard();
 
 let lastFrameTime = performance.now();
 let devicePixelRatioCache = window.devicePixelRatio || 1;
@@ -69,6 +72,12 @@ const render = (): void => {
 
   if (phase === "MENU") {
     renderMenuScene(context, width, height);
+    renderComplianceBoard(context, complianceBoard.getAll(), {
+      x: Math.max(16, width * 0.08),
+      y: height * 0.66,
+      width: Math.min(560, width - 32),
+      now: performance.now()
+    });
     return;
   }
 
@@ -158,6 +167,20 @@ if (DEV_MODE) {
 
     if (event.key.toLowerCase() === "s") {
       audioCache.play("sfx_card_play");
+    }
+
+    const damageKeyIndex = ["q", "w", "e", "r", "t"].indexOf(event.key.toLowerCase());
+    if (damageKeyIndex >= 0) {
+      complianceBoard.damage(INDICATORS[damageKeyIndex], 25);
+    }
+
+    if (event.key.toLowerCase() === "a") {
+      const lowest = complianceBoard.getLowest();
+      complianceBoard.restore(lowest.id, 20);
+    }
+
+    if (complianceBoard.isFailed()) {
+      gameState.setPhase("DEFEAT");
     }
   });
 }

--- a/src/ui/BoardRenderer.ts
+++ b/src/ui/BoardRenderer.ts
@@ -1,0 +1,64 @@
+import { COLORS } from "../config";
+import type { IndicatorState } from "../game/ComplianceBoard";
+
+interface BoardRenderOptions {
+  x: number;
+  y: number;
+  width: number;
+  now: number;
+}
+
+export const getIndicatorColor = (value: number): string => {
+  if (value > 60) {
+    return COLORS.safeGreen;
+  }
+
+  if (value >= 30) {
+    return COLORS.warnAmber;
+  }
+
+  return COLORS.dangerRed;
+};
+
+export const renderComplianceBoard = (
+  context: CanvasRenderingContext2D,
+  indicators: IndicatorState[],
+  options: BoardRenderOptions
+): void => {
+  const rowHeight = 34;
+  const labelWidth = Math.min(118, options.width * 0.32);
+  const valueWidth = 48;
+  const barWidth = Math.max(80, options.width - labelWidth - valueWidth - 28);
+
+  context.save();
+  context.textBaseline = "middle";
+
+  indicators.forEach((indicator, index) => {
+    const y = options.y + index * rowHeight;
+    const pulseAge = options.now - indicator.lastChangedAt;
+    const pulse = pulseAge >= 0 && pulseAge < 250 ? 1 - pulseAge / 250 : 0;
+
+    context.fillStyle = pulse > 0 ? "rgba(192, 57, 43, 0.22)" : "rgba(26, 26, 46, 0.72)";
+    context.fillRect(options.x, y, options.width, rowHeight - 7);
+
+    context.fillStyle = COLORS.text;
+    context.font = "700 14px system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif";
+    context.textAlign = "left";
+    context.fillText(indicator.label, options.x + 10, y + 14, labelWidth - 12);
+
+    const barX = options.x + labelWidth;
+    const barY = y + 8;
+    const barHeight = 12;
+
+    context.fillStyle = "#273247";
+    context.fillRect(barX, barY, barWidth, barHeight);
+    context.fillStyle = getIndicatorColor(indicator.value);
+    context.fillRect(barX, barY, barWidth * (indicator.value / 100), barHeight);
+
+    context.fillStyle = COLORS.text;
+    context.textAlign = "right";
+    context.fillText(`${indicator.value}%`, options.x + options.width - 10, y + 14, valueWidth);
+  });
+
+  context.restore();
+};

--- a/tests/ComplianceBoard.test.ts
+++ b/tests/ComplianceBoard.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { ComplianceBoard } from "../src/game/ComplianceBoard";
+
+describe("ComplianceBoard", () => {
+  it("starts every indicator at 100", () => {
+    const board = new ComplianceBoard();
+
+    expect(board.getAll().map((indicator) => indicator.value)).toEqual([100, 100, 100, 100, 100]);
+  });
+
+  it("applies damage and clamps at zero", () => {
+    const board = new ComplianceBoard();
+
+    expect(board.damage("ictrisk", 30)).toBe(70);
+    expect(board.damage("ictrisk", 200)).toBe(0);
+    expect(board.isFailed()).toBe(true);
+  });
+
+  it("restores indicators and clamps at 100", () => {
+    const board = new ComplianceBoard();
+
+    board.damage("thirdparty", 80);
+
+    expect(board.restore("thirdparty", 30)).toBe(50);
+    expect(board.restore("thirdparty", 999)).toBe(100);
+  });
+
+  it("damages multiple indicators and reports the lowest", () => {
+    const board = new ComplianceBoard();
+
+    board.damageMany([
+      { indicator: "incidents", amount: 15 },
+      { indicator: "reporting", amount: 45 }
+    ]);
+
+    expect(board.getLowest()).toMatchObject({ id: "reporting", value: 55 });
+  });
+
+  it("ignores negative damage and restore amounts", () => {
+    const board = new ComplianceBoard();
+
+    expect(board.damage("testing", -40)).toBe(100);
+    expect(board.restore("testing", -40)).toBe(100);
+  });
+});


### PR DESCRIPTION
## Summary

Adds the compliance health board: five indicators, deterministic damage/restore math, color-coded health bars, and dev controls to manually exercise board updates.

## What Changed

- Added `ComplianceBoard` with damage, restore, multi-target damage, lowest indicator, and failure detection.
- Added indicator constants and health colors.
- Added `BoardRenderer` with green/amber/red bars and damage pulse support.
- Rendered the board in the current menu checkpoint.
- Added dev keys to damage indicators and restore the lowest indicator.
- Added focused board unit tests.

## Validation

- `npm test`
- `npm run build`
- In-app browser tap + damage-key smoke check with no console errors.

Closes #5