### PR TITLE
[F-03] Card Deck + Hand System

### DIFF
--- a/src/game/CardDeck.ts
+++ b/src/game/CardDeck.ts
@@ -1,0 +1,331 @@
+import type { Indicator } from "./ComplianceBoard";
+
+export type CardType = "shield" | "restore" | "utility";
+export type CardTarget = Indicator | "all" | "incidents-testing" | "none";
+export type CardEffectKind = "block" | "restore" | "reduce-damage" | "draw" | "skip-attack";
+
+export interface CardEffect {
+  kind: CardEffectKind;
+  amount?: number;
+}
+
+export interface Card {
+  id: string;
+  name: string;
+  type: CardType;
+  target: CardTarget;
+  effect: CardEffect;
+  citation?: string;
+  description: string;
+  flavour: string;
+}
+
+export interface AttackLike {
+  type: Indicator | "security" | "any";
+  targets: Indicator[];
+}
+
+const createCards = (): Card[] => [
+  {
+    id: "dora-art5-shield",
+    name: "DORA Art.5 Shield",
+    type: "shield",
+    target: "ictrisk",
+    effect: { kind: "block" },
+    citation: "DORA Article 5",
+    description: "Block one ICT Risk attack.",
+    flavour: "Board oversight, but make it laminated."
+  },
+  {
+    id: "dora-art9-patch",
+    name: "DORA Art.9 Patch",
+    type: "restore",
+    target: "ictrisk",
+    effect: { kind: "restore", amount: 30 },
+    citation: "DORA Article 9",
+    description: "Restore ICT Risk by 30%.",
+    flavour: "Access controls: now with fewer mysterious exceptions."
+  },
+  {
+    id: "nis2-art21-barrier",
+    name: "NIS2 Art.21 Barrier",
+    type: "shield",
+    target: "incidents-testing",
+    effect: { kind: "block" },
+    citation: "NIS2 Article 21",
+    description: "Block Incident or Testing attacks.",
+    flavour: "A security measure with actual measures in it."
+  },
+  {
+    id: "incident-response-plan",
+    name: "Incident Response Plan",
+    type: "restore",
+    target: "incidents",
+    effect: { kind: "restore", amount: 80 },
+    citation: "DORA Article 17",
+    description: "Restore Incidents by 80%.",
+    flavour: "The incident bridge has snacks and consequences."
+  },
+  {
+    id: "third-party-register",
+    name: "Third-Party Register",
+    type: "restore",
+    target: "thirdparty",
+    effect: { kind: "restore", amount: 100 },
+    citation: "DORA Article 28",
+    description: "Restore Third-Party by 100%.",
+    flavour: "Every vendor, every appendix, every haunted renewal date."
+  },
+  {
+    id: "gdpr-art30-records",
+    name: "GDPR Art.30 Records",
+    type: "shield",
+    target: "all",
+    effect: { kind: "reduce-damage", amount: 20 },
+    citation: "GDPR Article 30",
+    description: "Reduce any attack damage by 20%.",
+    flavour: "A spreadsheet so complete it becomes a legal argument."
+  },
+  {
+    id: "emergency-patch",
+    name: "Emergency Patch",
+    type: "restore",
+    target: "all",
+    effect: { kind: "restore", amount: 50 },
+    citation: "DORA Article 9",
+    description: "Restore any indicator by 50%.",
+    flavour: "Tested in production, documented in hindsight."
+  },
+  {
+    id: "legal-counsel",
+    name: "Legal Counsel",
+    type: "utility",
+    target: "all",
+    effect: { kind: "skip-attack" },
+    citation: "DORA Article 28",
+    description: "Skip one attack entirely.",
+    flavour: "A calm voice enters the room. Everyone sits up straighter."
+  },
+  {
+    id: "coffee-break",
+    name: "Coffee Break",
+    type: "utility",
+    target: "none",
+    effect: { kind: "draw", amount: 2 },
+    description: "Draw 2 cards.",
+    flavour: "Sometimes you just need a moment."
+  },
+  {
+    id: "bcp-drill",
+    name: "BCP Drill",
+    type: "restore",
+    target: "testing",
+    effect: { kind: "restore", amount: 40 },
+    citation: "DORA Article 11",
+    description: "Restore Testing by 40%.",
+    flavour: "The tabletop exercise finally leaves the table."
+  },
+  {
+    id: "backup-evidence",
+    name: "Backup Evidence",
+    type: "shield",
+    target: "testing",
+    effect: { kind: "block" },
+    citation: "DORA Article 12",
+    description: "Block a Testing attack.",
+    flavour: "Screenshots, timestamps, and the sacred restore log."
+  },
+  {
+    id: "board-minutes",
+    name: "Board Minutes",
+    type: "shield",
+    target: "ictrisk",
+    effect: { kind: "block" },
+    citation: "DORA Article 5",
+    description: "Block ICT Risk governance findings.",
+    flavour: "Someone wrote it down. A miracle of governance."
+  },
+  {
+    id: "four-hour-report",
+    name: "4-Hour Report",
+    type: "restore",
+    target: "reporting",
+    effect: { kind: "restore", amount: 45 },
+    citation: "DORA Article 19",
+    description: "Restore Reporting by 45%.",
+    flavour: "Regulatory time moves differently during an outage."
+  },
+  {
+    id: "classification-matrix",
+    name: "Classification Matrix",
+    type: "shield",
+    target: "incidents",
+    effect: { kind: "block" },
+    citation: "DORA Article 18",
+    description: "Block an Incident Response attack.",
+    flavour: "Severity labels: now less vibes-based."
+  },
+  {
+    id: "vendor-exit-plan",
+    name: "Vendor Exit Plan",
+    type: "shield",
+    target: "thirdparty",
+    effect: { kind: "block" },
+    citation: "DORA Article 28",
+    description: "Block a Third-Party attack.",
+    flavour: "Breaking up is hard. Regulated breaking up is harder."
+  },
+  {
+    id: "threat-intel-briefing",
+    name: "Threat Intel Briefing",
+    type: "shield",
+    target: "incidents",
+    effect: { kind: "block" },
+    citation: "DORA Article 13",
+    description: "Block a cyber threat finding.",
+    flavour: "The threat actors also had a quarterly roadmap."
+  },
+  {
+    id: "rto-rpo-map",
+    name: "RTO/RPO Map",
+    type: "restore",
+    target: "testing",
+    effect: { kind: "restore", amount: 35 },
+    citation: "DORA Article 11",
+    description: "Restore Testing by 35%.",
+    flavour: "Two acronyms, one survivable weekend."
+  },
+  {
+    id: "concentration-review",
+    name: "Concentration Review",
+    type: "restore",
+    target: "thirdparty",
+    effect: { kind: "restore", amount: 50 },
+    citation: "DORA Article 29",
+    description: "Restore Third-Party by 50%.",
+    flavour: "It turns out all roads lead to the same cloud invoice."
+  },
+  {
+    id: "awareness-training",
+    name: "Awareness Training",
+    type: "restore",
+    target: "incidents",
+    effect: { kind: "restore", amount: 30 },
+    citation: "DORA Article 13",
+    description: "Restore Incidents by 30%.",
+    flavour: "Phishing simulations: because trust needed metrics."
+  },
+  {
+    id: "management-report",
+    name: "Management Report",
+    type: "restore",
+    target: "reporting",
+    effect: { kind: "restore", amount: 35 },
+    citation: "DORA Article 6",
+    description: "Restore Reporting by 35%.",
+    flavour: "A dashboard that says both less and more than anyone hoped."
+  }
+];
+
+export class CardDeck {
+  private readonly random: () => number;
+  private drawPile: Card[];
+  private discardPile: Card[] = [];
+  private hand: Card[] = [];
+
+  constructor(random: () => number = Math.random) {
+    this.random = random;
+    this.drawPile = this.shuffle(createCards());
+  }
+
+  getHand(): Card[] {
+    return [...this.hand];
+  }
+
+  getDrawPileCount(): number {
+    return this.drawPile.length;
+  }
+
+  getDiscardPileCount(): number {
+    return this.discardPile.length;
+  }
+
+  draw(count: number): Card[] {
+    const drawn: Card[] = [];
+
+    for (let index = 0; index < count; index += 1) {
+      this.reshuffleIfEmpty();
+      const card = this.drawPile.shift();
+
+      if (!card) {
+        break;
+      }
+
+      this.hand.push(card);
+      drawn.push(card);
+    }
+
+    return drawn;
+  }
+
+  play(cardId: string): Card | undefined {
+    const index = this.hand.findIndex((card) => card.id === cardId);
+
+    if (index < 0) {
+      return undefined;
+    }
+
+    const [card] = this.hand.splice(index, 1);
+    this.discardPile.push(card);
+
+    if (card.effect.kind === "draw") {
+      this.draw(card.effect.amount ?? 0);
+    }
+
+    return card;
+  }
+
+  discard(card: Card): void {
+    this.discardPile.push(card);
+  }
+
+  reshuffleIfEmpty(): void {
+    if (this.drawPile.length > 0 || this.discardPile.length === 0) {
+      return;
+    }
+
+    this.drawPile = this.shuffle(this.discardPile);
+    this.discardPile = [];
+  }
+
+  doesCardCounter(card: Card, attack: AttackLike): boolean {
+    if (card.effect.kind === "skip-attack") {
+      return true;
+    }
+
+    if (card.target === "all") {
+      return true;
+    }
+
+    if (card.target === "incidents-testing") {
+      return attack.targets.includes("incidents") || attack.targets.includes("testing");
+    }
+
+    if (card.target === "none") {
+      return false;
+    }
+
+    return attack.targets.includes(card.target);
+  }
+
+  private shuffle(cards: Card[]): Card[] {
+    const copy = [...cards];
+
+    for (let index = copy.length - 1; index > 0; index -= 1) {
+      const swapIndex = Math.floor(this.random() * (index + 1));
+      [copy[index], copy[swapIndex]] = [copy[swapIndex], copy[index]];
+    }
+
+    return copy;
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,11 +1,13 @@
 import { AudioCache } from "./audio/audioCache";
 import { getAudioManifest } from "./audio/elevenlabs";
 import { COLORS, DEBUG_SKIP_AUDIO, DEV_MODE, GAME_TITLE, INDICATORS, TOTAL_ROUNDS } from "./config";
+import { CardDeck } from "./game/CardDeck";
 import { ComplianceBoard } from "./game/ComplianceBoard";
 import { GameState, type Phase } from "./game/GameState";
 import { renderLoadingScene } from "./scenes/LoadingScene";
 import { renderMenuScene } from "./scenes/MenuScene";
 import { renderComplianceBoard } from "./ui/BoardRenderer";
+import { getCardAt, renderCards, type CardHitBox } from "./ui/CardRenderer";
 
 const canvas = document.querySelector<HTMLCanvasElement>("#game");
 
@@ -22,9 +24,13 @@ if (!context) {
 const gameState = new GameState("LOADING");
 const audioCache = new AudioCache(getAudioManifest(), { skipAudio: DEBUG_SKIP_AUDIO });
 const complianceBoard = new ComplianceBoard();
+const cardDeck = new CardDeck();
+cardDeck.draw(5);
 
 let lastFrameTime = performance.now();
 let devicePixelRatioCache = window.devicePixelRatio || 1;
+let pointer = { x: -1, y: -1 };
+let cardHitBoxes: CardHitBox[] = [];
 
 const resizeCanvas = (): void => {
   devicePixelRatioCache = window.devicePixelRatio || 1;
@@ -74,9 +80,16 @@ const render = (): void => {
     renderMenuScene(context, width, height);
     renderComplianceBoard(context, complianceBoard.getAll(), {
       x: Math.max(16, width * 0.08),
-      y: height * 0.66,
+      y: height * 0.56,
       width: Math.min(560, width - 32),
       now: performance.now()
+    });
+    cardHitBoxes = renderCards(context, cardDeck.getHand(), {
+      x: 16,
+      y: Math.max(height - 156, height * 0.76),
+      width: width - 32,
+      height: 136,
+      pointer
     });
     return;
   }
@@ -127,6 +140,14 @@ const loop = (frameTime: number): void => {
 };
 
 window.addEventListener("resize", resizeCanvas);
+canvas.addEventListener("pointermove", (event) => {
+  const rect = canvas.getBoundingClientRect();
+  pointer = {
+    x: event.clientX - rect.left,
+    y: event.clientY - rect.top
+  };
+});
+
 canvas.addEventListener("click", () => {
   if (gameState.getPhase() !== "TAP_TO_START") {
     return;
@@ -136,6 +157,24 @@ canvas.addEventListener("click", () => {
     gameState.setPhase("MENU");
     audioCache.play("music_menu");
   });
+});
+
+canvas.addEventListener("pointerdown", (event) => {
+  if (gameState.getPhase() !== "MENU") {
+    return;
+  }
+
+  const rect = canvas.getBoundingClientRect();
+  const cardId = getCardAt(cardHitBoxes, event.clientX - rect.left, event.clientY - rect.top);
+
+  if (!cardId) {
+    return;
+  }
+
+  const played = cardDeck.play(cardId);
+  if (played) {
+    audioCache.play("sfx_card_play");
+  }
 });
 
 if (DEV_MODE) {

--- a/src/ui/CardRenderer.ts
+++ b/src/ui/CardRenderer.ts
@@ -1,0 +1,77 @@
+import { COLORS } from "../config";
+import type { Card } from "../game/CardDeck";
+
+export interface CardHitBox {
+  cardId: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+interface CardRenderOptions {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  pointer?: { x: number; y: number };
+}
+
+export const getCardAt = (hitBoxes: CardHitBox[], x: number, y: number): string | undefined => {
+  return hitBoxes.find((box) => (
+    x >= box.x && x <= box.x + box.width && y >= box.y && y <= box.y + box.height
+  ))?.cardId;
+};
+
+export const renderCards = (
+  context: CanvasRenderingContext2D,
+  cards: Card[],
+  options: CardRenderOptions
+): CardHitBox[] => {
+  const gap = 10;
+  const cardWidth = Math.max(76, Math.min(150, (options.width - gap * (cards.length - 1)) / Math.max(1, cards.length)));
+  const cardHeight = options.height;
+  const hitBoxes: CardHitBox[] = [];
+
+  cards.forEach((card, index) => {
+    const x = options.x + index * (cardWidth + gap);
+    const isCoffee = card.id === "coffee-break";
+    const hovered = options.pointer
+      ? getCardAt([{ cardId: card.id, x, y: options.y, width: cardWidth, height: cardHeight }], options.pointer.x, options.pointer.y) === card.id
+      : false;
+    const y = hovered ? options.y - 8 : options.y;
+
+    hitBoxes.push({ cardId: card.id, x, y, width: cardWidth, height: cardHeight });
+
+    context.save();
+    context.fillStyle = "#182033";
+    context.strokeStyle = isCoffee ? "#8B4513" : COLORS.euBlue;
+    context.lineWidth = isCoffee ? 3 : 1.5;
+    context.fillRect(x, y, cardWidth, cardHeight);
+    context.strokeRect(x, y, cardWidth, cardHeight);
+
+    context.fillStyle = isCoffee ? "#c78b50" : COLORS.text;
+    context.font = "700 12px system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif";
+    context.textAlign = "left";
+    context.textBaseline = "top";
+    context.fillText(card.name, x + 8, y + 10, cardWidth - 16);
+
+    context.fillStyle = COLORS.muted;
+    context.font = "11px system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif";
+    context.fillText(card.citation ?? "No citation. Just coffee.", x + 8, y + 34, cardWidth - 16);
+
+    context.fillStyle = COLORS.text;
+    context.font = "12px system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif";
+    context.fillText(card.description, x + 8, y + 58, cardWidth - 16);
+
+    if (isCoffee) {
+      context.font = "28px system-ui, -apple-system, BlinkMacSystemFont, Segoe UI Emoji, sans-serif";
+      context.textAlign = "center";
+      context.fillText("☕", x + cardWidth / 2, y + cardHeight - 44);
+    }
+
+    context.restore();
+  });
+
+  return hitBoxes;
+};

--- a/tests/CardDeck.test.ts
+++ b/tests/CardDeck.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { CardDeck } from "../src/game/CardDeck";
+
+const predictableRandom = (): number => 0;
+
+describe("CardDeck", () => {
+  it("contains a 20-card deck and draws an opening hand of 5", () => {
+    const deck = new CardDeck(predictableRandom);
+
+    const hand = deck.draw(5);
+
+    expect(hand).toHaveLength(5);
+    expect(deck.getHand()).toHaveLength(5);
+    expect(deck.getDrawPileCount()).toBe(15);
+  });
+
+  it("plays a card from hand into discard", () => {
+    const deck = new CardDeck(predictableRandom);
+    const [card] = deck.draw(1);
+
+    const played = deck.play(card.id);
+
+    expect(played?.id).toBe(card.id);
+    expect(deck.getHand()).toHaveLength(0);
+    expect(deck.getDiscardPileCount()).toBe(1);
+  });
+
+  it("Coffee Break draws exactly 2 extra cards", () => {
+    const deck = new CardDeck(() => 0.99);
+    deck.draw(9);
+    const coffee = deck.getHand().find((card) => card.id === "coffee-break");
+
+    expect(coffee).toBeDefined();
+
+    const handSizeBefore = deck.getHand().length;
+    deck.play(coffee!.id);
+
+    expect(deck.getHand()).toHaveLength(handSizeBefore + 1);
+  });
+
+  it("Legal Counsel counters any attack", () => {
+    const deck = new CardDeck(predictableRandom);
+    deck.draw(20);
+    const counsel = deck.getHand().find((card) => card.id === "legal-counsel");
+
+    expect(counsel).toBeDefined();
+    expect(deck.doesCardCounter(counsel!, {
+      type: "any",
+      targets: ["ictrisk", "thirdparty", "reporting"]
+    })).toBe(true);
+  });
+
+  it("Coffee Break does not counter attacks", () => {
+    const deck = new CardDeck(predictableRandom);
+    deck.draw(20);
+    const coffee = deck.getHand().find((card) => card.id === "coffee-break");
+
+    expect(coffee).toBeDefined();
+    expect(deck.doesCardCounter(coffee!, {
+      type: "any",
+      targets: ["ictrisk"]
+    })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Adds the 20-card compliance deck and a visible, tappable hand checkpoint. Coffee Break draws two cards, Legal Counsel is modeled as a universal counter, and card hit-testing is ready for the upcoming regulator turn.

## What Changed

- Added `CardDeck` with 20 DORA/NIS2/GDPR-inspired cards.
- Added shuffle, draw, play, discard, reshuffle, and counter matching.
- Implemented Coffee Break draw behavior.
- Implemented Legal Counsel counter semantics.
- Added `CardRenderer` with hit boxes and a distinct Coffee Break style.
- Rendered the hand in the current menu checkpoint.
- Added card deck unit tests.

## Validation

- `npm test`
- `npm run build`
- In-app browser tap + card-area click smoke check with no console errors.

Closes #7