### PR TITLE
[F-04] Regulator AI + Round Script

### DIFF
--- a/src/game/RegulatorAI.ts
+++ b/src/game/RegulatorAI.ts
@@ -1,0 +1,175 @@
+import type { Indicator } from "./ComplianceBoard";
+
+export type RegulatorVoice = "standard" | "grand";
+
+export interface Attack {
+  round: number;
+  lineId: string;
+  text: string;
+  voice: RegulatorVoice;
+  targets: Indicator[];
+  damage: number;
+  type: Indicator | "security" | "any";
+}
+
+const ATTACKS: Attack[] = [
+  {
+    round: 1,
+    lineId: "dialogue_01_ictrisk",
+    text: "Your ICT Risk Management Framework lacks evidence of annual review. Article 5.",
+    voice: "standard",
+    targets: ["ictrisk"],
+    damage: 18,
+    type: "ictrisk"
+  },
+  {
+    round: 2,
+    lineId: "dialogue_02_incidents",
+    text: "The incident classification matrix is absent. Article 17 requires this.",
+    voice: "standard",
+    targets: ["incidents"],
+    damage: 18,
+    type: "incidents"
+  },
+  {
+    round: 3,
+    lineId: "dialogue_03_testing",
+    text: "No documented Business Continuity testing in the past 12 months. Article 11.",
+    voice: "standard",
+    targets: ["testing"],
+    damage: 20,
+    type: "testing"
+  },
+  {
+    round: 4,
+    lineId: "dialogue_04_thirdparty",
+    text: "Your third-party register lists 47 vendors. 23 show no contract review date.",
+    voice: "standard",
+    targets: ["thirdparty"],
+    damage: 20,
+    type: "thirdparty"
+  },
+  {
+    round: 5,
+    lineId: "dialogue_05_security",
+    text: "Multi-factor authentication is not enforced on 3 systems marked critical.",
+    voice: "standard",
+    targets: ["ictrisk"],
+    damage: 22,
+    type: "security"
+  },
+  {
+    round: 6,
+    lineId: "dialogue_11_threat_intel",
+    text: "This finding is CRITICAL. No documented cyber threat intelligence process.",
+    voice: "standard",
+    targets: ["incidents"],
+    damage: 26,
+    type: "incidents"
+  },
+  {
+    round: 7,
+    lineId: "dialogue_12_testing_inadequate",
+    text: "I am noting in the record that your testing program is thoroughly inadequate.",
+    voice: "standard",
+    targets: ["testing"],
+    damage: 28,
+    type: "testing"
+  },
+  {
+    round: 8,
+    lineId: "dialogue_13_rto_rpo",
+    text: "Your recovery time objectives exist. Your recovery point objectives do not.",
+    voice: "standard",
+    targets: ["testing"],
+    damage: 28,
+    type: "testing"
+  },
+  {
+    round: 9,
+    lineId: "dialogue_16_article_28",
+    text: "Your ICT third-party risk register is INCOMPLETE. Article 28. Paragraph 3.",
+    voice: "standard",
+    targets: ["thirdparty"],
+    damage: 30,
+    type: "thirdparty"
+  },
+  {
+    round: 10,
+    lineId: "dialogue_18_reporting",
+    text: "Your incident reporting timeline is 96 hours. The requirement is 4. Hours.",
+    voice: "standard",
+    targets: ["reporting"],
+    damage: 30,
+    type: "reporting"
+  },
+  {
+    round: 11,
+    lineId: "boss_01_disappointed",
+    text: "I have reviewed your compliance program in its entirety. I am... disappointed.",
+    voice: "grand",
+    targets: ["ictrisk", "thirdparty"],
+    damage: 24,
+    type: "any"
+  },
+  {
+    round: 12,
+    lineId: "boss_02_article_28",
+    text: "Article 28, paragraph 3. Your critical vendors. Where is the risk assessment?",
+    voice: "grand",
+    targets: ["thirdparty", "reporting"],
+    damage: 26,
+    type: "thirdparty"
+  },
+  {
+    round: 13,
+    lineId: "boss_04_simultaneous",
+    text: "I have flagged 5 simultaneous deficiencies. This is unprecedented in my career.",
+    voice: "grand",
+    targets: ["incidents", "testing", "reporting"],
+    damage: 22,
+    type: "any"
+  },
+  {
+    round: 14,
+    lineId: "boss_05_fine",
+    text: "The fine calculation is underway. The appeal process is lengthy. And costly.",
+    voice: "grand",
+    targets: ["ictrisk", "incidents", "thirdparty"],
+    damage: 24,
+    type: "any"
+  },
+  {
+    round: 15,
+    lineId: "boss_09_ten_million",
+    text: "Ten million euros is the preliminary figure. Subject to adjustment. Upward.",
+    voice: "grand",
+    targets: ["ictrisk", "incidents", "thirdparty", "testing", "reporting"],
+    damage: 18,
+    type: "any"
+  }
+];
+
+export class RegulatorAI {
+  getAttack(round: number): Attack {
+    const attack = ATTACKS.find((candidate) => candidate.round === round);
+
+    if (!attack) {
+      throw new Error(`No regulator attack configured for round ${round}`);
+    }
+
+    return attack;
+  }
+
+  isBossRound(round: number): boolean {
+    return round >= 11;
+  }
+
+  getTotalRounds(): number {
+    return ATTACKS.length;
+  }
+
+  getReaction(blocked: boolean): string {
+    return blocked ? "...Adequate. For now." : "As I suspected.";
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,8 +2,11 @@ import { AudioCache } from "./audio/audioCache";
 import { getAudioManifest } from "./audio/elevenlabs";
 import { COLORS, DEBUG_SKIP_AUDIO, DEV_MODE, GAME_TITLE, INDICATORS, TOTAL_ROUNDS } from "./config";
 import { CardDeck } from "./game/CardDeck";
-import { ComplianceBoard } from "./game/ComplianceBoard";
+import { ComplianceBoard, type Indicator } from "./game/ComplianceBoard";
 import { GameState, type Phase } from "./game/GameState";
+import { RegulatorAI, type Attack } from "./game/RegulatorAI";
+import { renderBossIntroScene } from "./scenes/BossScene";
+import { renderGameScene } from "./scenes/GameScene";
 import { renderLoadingScene } from "./scenes/LoadingScene";
 import { renderMenuScene } from "./scenes/MenuScene";
 import { renderComplianceBoard } from "./ui/BoardRenderer";
@@ -25,12 +28,56 @@ const gameState = new GameState("LOADING");
 const audioCache = new AudioCache(getAudioManifest(), { skipAudio: DEBUG_SKIP_AUDIO });
 const complianceBoard = new ComplianceBoard();
 const cardDeck = new CardDeck();
+const regulatorAI = new RegulatorAI();
 cardDeck.draw(5);
 
 let lastFrameTime = performance.now();
 let devicePixelRatioCache = window.devicePixelRatio || 1;
 let pointer = { x: -1, y: -1 };
 let cardHitBoxes: CardHitBox[] = [];
+let currentRound = 0;
+let currentAttack: Attack | undefined;
+let currentReaction = "";
+
+const startRound = (round: number): void => {
+  currentRound = round;
+  currentAttack = regulatorAI.getAttack(round);
+  currentReaction = "";
+  gameState.setPhase(regulatorAI.isBossRound(round) ? "BOSS_TURN" : "PLAYER_TURN");
+};
+
+const advanceRound = (): void => {
+  if (complianceBoard.isFailed()) {
+    gameState.setPhase("DEFEAT");
+    return;
+  }
+
+  if (currentRound >= regulatorAI.getTotalRounds()) {
+    gameState.setPhase("VICTORY");
+    return;
+  }
+
+  startRound(currentRound + 1);
+};
+
+const restoreTargets = (target: Indicator | "all" | "incidents-testing" | "none", amount: number): void => {
+  if (target === "none") {
+    return;
+  }
+
+  if (target === "all") {
+    complianceBoard.restore(complianceBoard.getLowest().id, amount);
+    return;
+  }
+
+  if (target === "incidents-testing") {
+    complianceBoard.restore("incidents", amount);
+    complianceBoard.restore("testing", amount);
+    return;
+  }
+
+  complianceBoard.restore(target, amount);
+};
 
 const resizeCanvas = (): void => {
   devicePixelRatioCache = window.devicePixelRatio || 1;
@@ -94,8 +141,43 @@ const render = (): void => {
     return;
   }
 
+  if (phase === "BOSS_INTRO") {
+    renderBossIntroScene(context, width, height);
+    return;
+  }
+
   context.fillStyle = COLORS.background;
   context.fillRect(0, 0, width, height);
+
+  if ((phase === "PLAYER_TURN" || phase === "BOSS_TURN") && currentAttack) {
+    renderGameScene(context, width, currentAttack, currentReaction);
+    renderComplianceBoard(context, complianceBoard.getAll(), {
+      x: Math.max(16, width * 0.08),
+      y: 210,
+      width: Math.min(560, width - 32),
+      now: performance.now()
+    });
+    cardHitBoxes = renderCards(context, cardDeck.getHand(), {
+      x: 16,
+      y: Math.max(height - 156, height * 0.76),
+      width: width - 32,
+      height: 136,
+      pointer
+    });
+    return;
+  }
+
+  if (phase === "VICTORY" || phase === "DEFEAT") {
+    drawCenteredText(
+      phase === "VICTORY"
+        ? "You have survived the audit. You will not be fined... this quarter."
+        : "EUR 10,000,000. The fine has been calculated.",
+      height * 0.48,
+      width < 520 ? 20 : 28,
+      phase === "VICTORY" ? COLORS.safeGreen : COLORS.dangerRed
+    );
+    return;
+  }
 
   context.fillStyle = COLORS.surface;
   context.fillRect(0, 0, width, 72);
@@ -160,21 +242,43 @@ canvas.addEventListener("click", () => {
 });
 
 canvas.addEventListener("pointerdown", (event) => {
-  if (gameState.getPhase() !== "MENU") {
+  if (gameState.getPhase() === "MENU") {
+    startRound(1);
+    return;
+  }
+
+  if (gameState.getPhase() !== "PLAYER_TURN" && gameState.getPhase() !== "BOSS_TURN") {
     return;
   }
 
   const rect = canvas.getBoundingClientRect();
   const cardId = getCardAt(cardHitBoxes, event.clientX - rect.left, event.clientY - rect.top);
 
-  if (!cardId) {
+  if (!cardId || !currentAttack) {
     return;
   }
 
   const played = cardDeck.play(cardId);
-  if (played) {
-    audioCache.play("sfx_card_play");
+  if (!played) {
+    return;
   }
+
+  audioCache.play("sfx_card_play");
+
+  const blocked = cardDeck.doesCardCounter(played, currentAttack);
+  if (blocked && played.effect.kind === "restore") {
+    restoreTargets(played.target, played.effect.amount ?? 0);
+  }
+
+  if (!blocked) {
+    complianceBoard.damageMany(currentAttack.targets.map((indicator) => ({
+      indicator,
+      amount: currentAttack?.damage ?? 0
+    })));
+  }
+
+  currentReaction = regulatorAI.getReaction(blocked);
+  advanceRound();
 });
 
 if (DEV_MODE) {

--- a/src/scenes/BossScene.ts
+++ b/src/scenes/BossScene.ts
@@ -1,0 +1,20 @@
+import { COLORS } from "../config";
+
+export const renderBossIntroScene = (
+  context: CanvasRenderingContext2D,
+  width: number,
+  height: number
+): void => {
+  context.fillStyle = COLORS.background;
+  context.fillRect(0, 0, width, height);
+
+  context.fillStyle = COLORS.dangerRed;
+  context.font = "700 28px system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif";
+  context.textAlign = "center";
+  context.textBaseline = "middle";
+  context.fillText("GRAND REGULATOR APPROACHING", width / 2, height * 0.44, Math.max(260, width - 48));
+
+  context.fillStyle = COLORS.text;
+  context.font = "16px system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif";
+  context.fillText("The audit has escalated.", width / 2, height * 0.52);
+};

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -1,0 +1,36 @@
+import { COLORS, TOTAL_ROUNDS } from "../config";
+import type { Attack } from "../game/RegulatorAI";
+
+export const renderGameScene = (
+  context: CanvasRenderingContext2D,
+  width: number,
+  attack: Attack,
+  reaction: string
+): void => {
+  context.fillStyle = COLORS.surface;
+  context.fillRect(0, 0, width, 72);
+
+  context.fillStyle = COLORS.text;
+  context.font = "700 18px system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif";
+  context.textAlign = "left";
+  context.textBaseline = "middle";
+  context.fillText("DORA: The Compliance Roguelike", 24, 36, Math.max(140, width - 180));
+
+  context.textAlign = "right";
+  context.fillText(`Round ${attack.round} / ${TOTAL_ROUNDS}`, width - 24, 36, 140);
+
+  context.textAlign = "center";
+  context.fillStyle = attack.voice === "grand" ? COLORS.dangerRed : COLORS.euBlue;
+  context.font = "700 16px system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif";
+  context.fillText(attack.voice === "grand" ? "GRAND REGULATOR" : "REGULATOR", width / 2, 104);
+
+  context.fillStyle = COLORS.text;
+  context.font = "700 18px system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif";
+  context.fillText(attack.text, width / 2, 140, Math.max(260, width - 48));
+
+  if (reaction) {
+    context.fillStyle = COLORS.muted;
+    context.font = "16px system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif";
+    context.fillText(reaction, width / 2, 174, Math.max(260, width - 48));
+  }
+};

--- a/src/scenes/MenuScene.ts
+++ b/src/scenes/MenuScene.ts
@@ -20,5 +20,5 @@ export const renderMenuScene = (
 
   context.fillStyle = COLORS.muted;
   context.font = "14px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace";
-  context.fillText("Dev keys: D dialogue, M music, S sfx", width / 2, height * 0.58, Math.max(260, width - 48));
+  context.fillText("Tap anywhere outside a card to start Round 1.", width / 2, height * 0.56, Math.max(260, width - 48));
 };

--- a/tests/RegulatorAI.test.ts
+++ b/tests/RegulatorAI.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { RegulatorAI } from "../src/game/RegulatorAI";
+
+describe("RegulatorAI", () => {
+  it("provides 15 configured rounds", () => {
+    const ai = new RegulatorAI();
+
+    expect(ai.getTotalRounds()).toBe(15);
+    expect(ai.getAttack(1)).toMatchObject({ round: 1, voice: "standard" });
+    expect(ai.getAttack(15)).toMatchObject({ round: 15, voice: "grand" });
+  });
+
+  it("marks rounds 11 through 15 as boss rounds", () => {
+    const ai = new RegulatorAI();
+
+    expect(ai.isBossRound(10)).toBe(false);
+    expect(ai.isBossRound(11)).toBe(true);
+  });
+
+  it("makes boss attacks hit multiple indicators", () => {
+    const ai = new RegulatorAI();
+
+    expect(ai.getAttack(13).targets.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("throws for unconfigured rounds", () => {
+    const ai = new RegulatorAI();
+
+    expect(() => ai.getAttack(16)).toThrow("No regulator attack configured");
+  });
+});


### PR DESCRIPTION
## Summary

Adds the 15-round regulator sequence, boss-phase attacks, card-vs-attack resolution, damage application, and win/loss transitions.

## What Changed

- Added `RegulatorAI` with 15 configured attacks.
- Added standard and grand regulator voice metadata.
- Added boss rounds from round 11 onward.
- Added game and boss scene renderers.
- Wired menu start into active player/boss turns.
- Wired card play to block, restore, or apply attack damage.
- Added victory and defeat transitions.
- Added RegulatorAI unit tests.

## Validation

- `npm test`
- `npm run build`
- Browser smoke path from loading to menu to round/card click with no console errors.

Closes #9