### PR TITLE
[F-05] Timed Turn Loop

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,6 @@
 export const GAME_TITLE = "DORA: The Compliance Roguelike";
 export const TOTAL_ROUNDS = 15;
+export const CARD_TIMER_SECONDS = 15;
 export const DEV_MODE = import.meta.env.DEV;
 export const DEBUG_SKIP_AUDIO = import.meta.env.VITE_DEBUG_SKIP_AUDIO !== "false";
 

--- a/src/game/TurnTimer.ts
+++ b/src/game/TurnTimer.ts
@@ -1,0 +1,47 @@
+export class TurnTimer {
+  private readonly durationSeconds: number;
+  private remainingSeconds: number;
+  private running = false;
+  private resolved = false;
+
+  constructor(durationSeconds: number) {
+    this.durationSeconds = durationSeconds;
+    this.remainingSeconds = durationSeconds;
+  }
+
+  start(): void {
+    this.remainingSeconds = this.durationSeconds;
+    this.running = true;
+    this.resolved = false;
+  }
+
+  stop(): void {
+    this.running = false;
+  }
+
+  update(deltaSeconds: number): void {
+    if (!this.running || this.resolved) {
+      return;
+    }
+
+    this.remainingSeconds = Math.max(0, this.remainingSeconds - Math.max(0, deltaSeconds));
+  }
+
+  resolve(): boolean {
+    if (this.resolved) {
+      return false;
+    }
+
+    this.resolved = true;
+    this.running = false;
+    return true;
+  }
+
+  isExpired(): boolean {
+    return this.running && !this.resolved && this.remainingSeconds <= 0;
+  }
+
+  getRemainingSeconds(): number {
+    return this.remainingSeconds;
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,16 +1,18 @@
 import { AudioCache } from "./audio/audioCache";
 import { getAudioManifest } from "./audio/elevenlabs";
-import { COLORS, DEBUG_SKIP_AUDIO, DEV_MODE, GAME_TITLE, INDICATORS, TOTAL_ROUNDS } from "./config";
+import { CARD_TIMER_SECONDS, COLORS, DEBUG_SKIP_AUDIO, DEV_MODE, GAME_TITLE, INDICATORS, TOTAL_ROUNDS } from "./config";
 import { CardDeck } from "./game/CardDeck";
 import { ComplianceBoard, type Indicator } from "./game/ComplianceBoard";
 import { GameState, type Phase } from "./game/GameState";
 import { RegulatorAI, type Attack } from "./game/RegulatorAI";
+import { TurnTimer } from "./game/TurnTimer";
 import { renderBossIntroScene } from "./scenes/BossScene";
 import { renderGameScene } from "./scenes/GameScene";
 import { renderLoadingScene } from "./scenes/LoadingScene";
 import { renderMenuScene } from "./scenes/MenuScene";
 import { renderComplianceBoard } from "./ui/BoardRenderer";
 import { getCardAt, renderCards, type CardHitBox } from "./ui/CardRenderer";
+import { renderTurnTimer } from "./ui/HUD";
 
 const canvas = document.querySelector<HTMLCanvasElement>("#game");
 
@@ -29,6 +31,7 @@ const audioCache = new AudioCache(getAudioManifest(), { skipAudio: DEBUG_SKIP_AU
 const complianceBoard = new ComplianceBoard();
 const cardDeck = new CardDeck();
 const regulatorAI = new RegulatorAI();
+const turnTimer = new TurnTimer(CARD_TIMER_SECONDS);
 cardDeck.draw(5);
 
 let lastFrameTime = performance.now();
@@ -43,6 +46,7 @@ const startRound = (round: number): void => {
   currentRound = round;
   currentAttack = regulatorAI.getAttack(round);
   currentReaction = "";
+  turnTimer.start();
   gameState.setPhase(regulatorAI.isBossRound(round) ? "BOSS_TURN" : "PLAYER_TURN");
 };
 
@@ -77,6 +81,32 @@ const restoreTargets = (target: Indicator | "all" | "incidents-testing" | "none"
   }
 
   complianceBoard.restore(target, amount);
+};
+
+const resolveRound = (cardId?: string): void => {
+  if (!currentAttack || !turnTimer.resolve()) {
+    return;
+  }
+
+  const played = cardId ? cardDeck.play(cardId) : undefined;
+  if (played) {
+    audioCache.play("sfx_card_play");
+  }
+
+  const blocked = played ? cardDeck.doesCardCounter(played, currentAttack) : false;
+  if (blocked && played?.effect.kind === "restore") {
+    restoreTargets(played.target, played.effect.amount ?? 0);
+  }
+
+  if (!blocked) {
+    complianceBoard.damageMany(currentAttack.targets.map((indicator) => ({
+      indicator,
+      amount: currentAttack?.damage ?? 0
+    })));
+  }
+
+  currentReaction = regulatorAI.getReaction(blocked);
+  advanceRound();
 };
 
 const resizeCanvas = (): void => {
@@ -151,6 +181,7 @@ const render = (): void => {
 
   if ((phase === "PLAYER_TURN" || phase === "BOSS_TURN") && currentAttack) {
     renderGameScene(context, width, currentAttack, currentReaction);
+    renderTurnTimer(context, width, turnTimer.getRemainingSeconds());
     renderComplianceBoard(context, complianceBoard.getAll(), {
       x: Math.max(16, width * 0.08),
       y: 210,
@@ -210,6 +241,14 @@ const render = (): void => {
 
 const update = (deltaSeconds: number): void => {
   gameState.update(deltaSeconds);
+
+  if (gameState.getPhase() === "PLAYER_TURN" || gameState.getPhase() === "BOSS_TURN") {
+    turnTimer.update(deltaSeconds);
+
+    if (turnTimer.isExpired()) {
+      resolveRound();
+    }
+  }
 };
 
 const loop = (frameTime: number): void => {
@@ -258,27 +297,7 @@ canvas.addEventListener("pointerdown", (event) => {
     return;
   }
 
-  const played = cardDeck.play(cardId);
-  if (!played) {
-    return;
-  }
-
-  audioCache.play("sfx_card_play");
-
-  const blocked = cardDeck.doesCardCounter(played, currentAttack);
-  if (blocked && played.effect.kind === "restore") {
-    restoreTargets(played.target, played.effect.amount ?? 0);
-  }
-
-  if (!blocked) {
-    complianceBoard.damageMany(currentAttack.targets.map((indicator) => ({
-      indicator,
-      amount: currentAttack?.damage ?? 0
-    })));
-  }
-
-  currentReaction = regulatorAI.getReaction(blocked);
-  advanceRound();
+  resolveRound(cardId);
 });
 
 if (DEV_MODE) {

--- a/src/ui/HUD.ts
+++ b/src/ui/HUD.ts
@@ -1,0 +1,15 @@
+import { COLORS } from "../config";
+
+export const renderTurnTimer = (
+  context: CanvasRenderingContext2D,
+  width: number,
+  remainingSeconds: number
+): void => {
+  const danger = remainingSeconds < 5;
+
+  context.fillStyle = danger ? COLORS.dangerRed : COLORS.text;
+  context.font = "700 18px system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif";
+  context.textAlign = "center";
+  context.textBaseline = "middle";
+  context.fillText(`Your hand - ${Math.ceil(remainingSeconds)} seconds`, width / 2, 198);
+};

--- a/tests/TurnTimer.test.ts
+++ b/tests/TurnTimer.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { TurnTimer } from "../src/game/TurnTimer";
+
+describe("TurnTimer", () => {
+  it("starts at the configured duration", () => {
+    const timer = new TurnTimer(15);
+
+    timer.start();
+
+    expect(timer.getRemainingSeconds()).toBe(15);
+  });
+
+  it("counts down while running and clamps at zero", () => {
+    const timer = new TurnTimer(15);
+
+    timer.start();
+    timer.update(4.5);
+    timer.update(20);
+
+    expect(timer.getRemainingSeconds()).toBe(0);
+    expect(timer.isExpired()).toBe(true);
+  });
+
+  it("ignores negative deltas", () => {
+    const timer = new TurnTimer(15);
+
+    timer.start();
+    timer.update(-2);
+
+    expect(timer.getRemainingSeconds()).toBe(15);
+  });
+
+  it("prevents double resolution", () => {
+    const timer = new TurnTimer(15);
+
+    timer.start();
+
+    expect(timer.resolve()).toBe(true);
+    expect(timer.resolve()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Adds the 15-second decision timer for each regulator round, including immediate card resolution, no-card timeout resolution, HUD display, red warning state, and double-resolution protection.

## What Changed

- Added `TurnTimer` with one-shot resolution guard.
- Added HUD timer rendering.
- Starts timer each round.
- Resolves no-card response on expiry.
- Keeps card click resolution immediate.
- Added TurnTimer unit tests.

## Validation

- `npm test`
- `npm run build`
- Browser smoke path with no console errors.

Closes #11