### PR TITLE
[F-06] Visual Identity + Regulator Character

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -7,12 +7,15 @@ import { GameState, type Phase } from "./game/GameState";
 import { RegulatorAI, type Attack } from "./game/RegulatorAI";
 import { TurnTimer } from "./game/TurnTimer";
 import { renderBossIntroScene } from "./scenes/BossScene";
+import { renderDefeatScene } from "./scenes/DefeatScene";
 import { renderGameScene } from "./scenes/GameScene";
 import { renderLoadingScene } from "./scenes/LoadingScene";
 import { renderMenuScene } from "./scenes/MenuScene";
+import { renderVictoryScene } from "./scenes/VictoryScene";
 import { renderComplianceBoard } from "./ui/BoardRenderer";
 import { getCardAt, renderCards, type CardHitBox } from "./ui/CardRenderer";
 import { renderTurnTimer } from "./ui/HUD";
+import { renderRegulator } from "./ui/RegulatorRenderer";
 
 const canvas = document.querySelector<HTMLCanvasElement>("#game");
 
@@ -181,6 +184,7 @@ const render = (): void => {
 
   if ((phase === "PLAYER_TURN" || phase === "BOSS_TURN") && currentAttack) {
     renderGameScene(context, width, currentAttack, currentReaction);
+    renderRegulator(context, width - 112, 190, currentAttack.voice, true, performance.now());
     renderTurnTimer(context, width, turnTimer.getRemainingSeconds());
     renderComplianceBoard(context, complianceBoard.getAll(), {
       x: Math.max(16, width * 0.08),
@@ -199,14 +203,11 @@ const render = (): void => {
   }
 
   if (phase === "VICTORY" || phase === "DEFEAT") {
-    drawCenteredText(
-      phase === "VICTORY"
-        ? "You have survived the audit. You will not be fined... this quarter."
-        : "EUR 10,000,000. The fine has been calculated.",
-      height * 0.48,
-      width < 520 ? 20 : 28,
-      phase === "VICTORY" ? COLORS.safeGreen : COLORS.dangerRed
-    );
+    if (phase === "VICTORY") {
+      renderVictoryScene(context, width, height);
+    } else {
+      renderDefeatScene(context, width, height);
+    }
     return;
   }
 

--- a/src/scenes/DefeatScene.ts
+++ b/src/scenes/DefeatScene.ts
@@ -1,0 +1,20 @@
+import { COLORS } from "../config";
+
+export const renderDefeatScene = (
+  context: CanvasRenderingContext2D,
+  width: number,
+  height: number
+): void => {
+  context.fillStyle = COLORS.background;
+  context.fillRect(0, 0, width, height);
+
+  context.fillStyle = COLORS.dangerRed;
+  context.font = "700 38px system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif";
+  context.textAlign = "center";
+  context.textBaseline = "middle";
+  context.fillText("EUR 10,000,000", width / 2, height * 0.42, Math.max(260, width - 48));
+
+  context.fillStyle = COLORS.text;
+  context.font = "700 22px system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif";
+  context.fillText("The fine has been calculated.", width / 2, height * 0.52, Math.max(260, width - 48));
+};

--- a/src/scenes/VictoryScene.ts
+++ b/src/scenes/VictoryScene.ts
@@ -1,0 +1,20 @@
+import { COLORS } from "../config";
+
+export const renderVictoryScene = (
+  context: CanvasRenderingContext2D,
+  width: number,
+  height: number
+): void => {
+  context.fillStyle = COLORS.background;
+  context.fillRect(0, 0, width, height);
+
+  context.fillStyle = COLORS.safeGreen;
+  context.font = "700 30px system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif";
+  context.textAlign = "center";
+  context.textBaseline = "middle";
+  context.fillText("You have survived the audit.", width / 2, height * 0.42, Math.max(260, width - 48));
+
+  context.fillStyle = COLORS.text;
+  context.font = "700 22px system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif";
+  context.fillText("You will not be fined... this quarter.", width / 2, height * 0.52, Math.max(260, width - 48));
+};

--- a/src/ui/RegulatorRenderer.ts
+++ b/src/ui/RegulatorRenderer.ts
@@ -1,0 +1,76 @@
+import { COLORS } from "../config";
+import type { RegulatorVoice } from "../game/RegulatorAI";
+
+export const getRegulatorAccent = (voice: RegulatorVoice): string => (
+  voice === "grand" ? COLORS.dangerRed : COLORS.euBlue
+);
+
+export const renderRegulator = (
+  context: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  voice: RegulatorVoice,
+  speaking: boolean,
+  now: number
+): void => {
+  const accent = getRegulatorAccent(voice);
+  const sway = speaking ? Math.sin(now / 240) * 0.04 : 0;
+
+  context.save();
+  context.translate(x, y);
+  context.rotate(sway);
+
+  context.fillStyle = "#101827";
+  context.strokeStyle = accent;
+  context.lineWidth = 2;
+
+  context.beginPath();
+  context.arc(0, -44, 22, 0, Math.PI * 2);
+  context.fill();
+  context.stroke();
+
+  context.fillRect(-28, -20, 56, 74);
+  context.strokeRect(-28, -20, 56, 74);
+
+  context.fillStyle = accent;
+  context.beginPath();
+  context.moveTo(0, -10);
+  context.lineTo(8, 18);
+  context.lineTo(0, 30);
+  context.lineTo(-8, 18);
+  context.closePath();
+  context.fill();
+
+  context.fillStyle = "#29384d";
+  context.fillRect(28, 18, 34, 28);
+  context.strokeRect(28, 18, 34, 28);
+
+  context.fillStyle = accent;
+  context.beginPath();
+  context.arc(18, -4, 4, 0, Math.PI * 2);
+  context.fill();
+
+  context.restore();
+
+  renderWaveform(context, x, y + 76, accent, speaking, now);
+};
+
+const renderWaveform = (
+  context: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  color: string,
+  speaking: boolean,
+  now: number
+): void => {
+  context.save();
+  context.fillStyle = color;
+
+  for (let index = 0; index < 9; index += 1) {
+    const phase = now / 120 + index * 0.8;
+    const height = speaking ? 8 + Math.abs(Math.sin(phase)) * 24 : 8;
+    context.fillRect(x - 45 + index * 11, y - height / 2, 5, height);
+  }
+
+  context.restore();
+};

--- a/tests/RegulatorRenderer.test.ts
+++ b/tests/RegulatorRenderer.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { COLORS } from "../src/config";
+import { getRegulatorAccent } from "../src/ui/RegulatorRenderer";
+
+describe("RegulatorRenderer", () => {
+  it("uses EU blue for the standard regulator", () => {
+    expect(getRegulatorAccent("standard")).toBe(COLORS.euBlue);
+  });
+
+  it("uses danger red for the grand regulator", () => {
+    expect(getRegulatorAccent("grand")).toBe(COLORS.dangerRed);
+  });
+});


### PR DESCRIPTION
## Summary

Adds the visual regulator character, waveform animation, grand-regulator accent difference, and dedicated victory/defeat screens for clearer video capture.

## What Changed

- Added `RegulatorRenderer` with faceless suited silhouette, briefcase, EU pin, and waveform bars.
- Added distinct standard vs grand regulator accent colors.
- Added `VictoryScene` and `DefeatScene`.
- Rendered regulator during active rounds.
- Added renderer utility tests.

## Validation

- `npm test`
- `npm run build`
- Browser smoke path with no console errors.

Closes #13