### PR TITLE
[F-07] Adaptive Music + SFX

### DIFF
--- a/src/audio/MusicDirector.ts
+++ b/src/audio/MusicDirector.ts
@@ -1,0 +1,41 @@
+import type { Phase } from "../game/GameState";
+
+export type MusicTrackId =
+  | "music_menu"
+  | "music_gameplay_calm"
+  | "music_gameplay_tense"
+  | "music_boss"
+  | "music_victory"
+  | "music_defeat";
+
+export const selectMusicTrack = (
+  phase: Phase,
+  lowestIndicatorValue: number,
+  bossRound: boolean
+): MusicTrackId | undefined => {
+  if (phase === "MENU" || phase === "TAP_TO_START") {
+    return "music_menu";
+  }
+
+  if (phase === "VICTORY") {
+    return "music_victory";
+  }
+
+  if (phase === "DEFEAT") {
+    return "music_defeat";
+  }
+
+  if (phase === "BOSS_TURN" || phase === "BOSS_INTRO" || bossRound || lowestIndicatorValue < 30) {
+    return "music_boss";
+  }
+
+  if (phase === "PLAYER_TURN" && lowestIndicatorValue < 60) {
+    return "music_gameplay_tense";
+  }
+
+  if (phase === "PLAYER_TURN") {
+    return "music_gameplay_calm";
+  }
+
+  return undefined;
+};

--- a/src/audio/elevenlabs.ts
+++ b/src/audio/elevenlabs.ts
@@ -23,10 +23,67 @@ export const AUDIO_MANIFEST: AudioAsset[] = [
     loop: true
   },
   {
+    id: "music_gameplay_calm",
+    type: "music",
+    src: "/audio/music_gameplay_calm.mp3",
+    volume: 0.15,
+    loop: true
+  },
+  {
+    id: "music_gameplay_tense",
+    type: "music",
+    src: "/audio/music_gameplay_tense.mp3",
+    volume: 0.15,
+    loop: true
+  },
+  {
+    id: "music_boss",
+    type: "music",
+    src: "/audio/music_boss.mp3",
+    volume: 0.15,
+    loop: true
+  },
+  {
+    id: "music_victory",
+    type: "music",
+    src: "/audio/music_victory.mp3",
+    volume: 0.15
+  },
+  {
+    id: "music_defeat",
+    type: "music",
+    src: "/audio/music_defeat.mp3",
+    volume: 0.15
+  },
+  {
     id: "sfx_card_play",
     type: "sfx",
     src: "/audio/sfx_card_play.mp3",
     volume: 0.6
+  },
+  {
+    id: "sfx_card_block",
+    type: "sfx",
+    src: "/audio/sfx_card_block.mp3",
+    volume: 0.6
+  },
+  {
+    id: "sfx_damage",
+    type: "sfx",
+    src: "/audio/sfx_damage.mp3",
+    volume: 0.6
+  },
+  {
+    id: "sfx_critical_damage",
+    type: "sfx",
+    src: "/audio/sfx_critical_damage.mp3",
+    volume: 0.7
+  },
+  {
+    id: "sfx_boss_entrance",
+    type: "sfx",
+    src: "/audio/sfx_boss_entrance.mp3",
+    volume: 0.7
   }
 ];
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import { AudioCache } from "./audio/audioCache";
 import { getAudioManifest } from "./audio/elevenlabs";
+import { selectMusicTrack, type MusicTrackId } from "./audio/MusicDirector";
 import { CARD_TIMER_SECONDS, COLORS, DEBUG_SKIP_AUDIO, DEV_MODE, GAME_TITLE, INDICATORS, TOTAL_ROUNDS } from "./config";
 import { CardDeck } from "./game/CardDeck";
 import { ComplianceBoard, type Indicator } from "./game/ComplianceBoard";
@@ -44,6 +45,27 @@ let cardHitBoxes: CardHitBox[] = [];
 let currentRound = 0;
 let currentAttack: Attack | undefined;
 let currentReaction = "";
+let currentMusic: MusicTrackId | undefined;
+
+const updateMusic = (): void => {
+  const nextMusic = selectMusicTrack(
+    gameState.getPhase(),
+    complianceBoard.getLowest().value,
+    currentAttack ? regulatorAI.isBossRound(currentAttack.round) : false
+  );
+
+  if (!nextMusic || nextMusic === currentMusic) {
+    return;
+  }
+
+  if (currentMusic) {
+    audioCache.crossfade(currentMusic, nextMusic, 650);
+  } else {
+    audioCache.play(nextMusic);
+  }
+
+  currentMusic = nextMusic;
+};
 
 const startRound = (round: number): void => {
   currentRound = round;
@@ -51,16 +73,22 @@ const startRound = (round: number): void => {
   currentReaction = "";
   turnTimer.start();
   gameState.setPhase(regulatorAI.isBossRound(round) ? "BOSS_TURN" : "PLAYER_TURN");
+
+  if (round === 11) {
+    audioCache.play("sfx_boss_entrance");
+  }
 };
 
 const advanceRound = (): void => {
   if (complianceBoard.isFailed()) {
     gameState.setPhase("DEFEAT");
+    audioCache.play("music_defeat");
     return;
   }
 
   if (currentRound >= regulatorAI.getTotalRounds()) {
     gameState.setPhase("VICTORY");
+    audioCache.play("music_victory");
     return;
   }
 
@@ -106,6 +134,9 @@ const resolveRound = (cardId?: string): void => {
       indicator,
       amount: currentAttack?.damage ?? 0
     })));
+    audioCache.play(complianceBoard.getLowest().value < 30 ? "sfx_critical_damage" : "sfx_damage");
+  } else {
+    audioCache.play("sfx_card_block");
   }
 
   currentReaction = regulatorAI.getReaction(blocked);
@@ -250,6 +281,8 @@ const update = (deltaSeconds: number): void => {
       resolveRound();
     }
   }
+
+  updateMusic();
 };
 
 const loop = (frameTime: number): void => {

--- a/tests/MusicDirector.test.ts
+++ b/tests/MusicDirector.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { selectMusicTrack } from "../src/audio/MusicDirector";
+
+describe("MusicDirector", () => {
+  it("uses calm gameplay music when compliance is healthy", () => {
+    expect(selectMusicTrack("PLAYER_TURN", 80, false)).toBe("music_gameplay_calm");
+  });
+
+  it("uses tense gameplay music below 60", () => {
+    expect(selectMusicTrack("PLAYER_TURN", 55, false)).toBe("music_gameplay_tense");
+  });
+
+  it("uses boss music below 30 or during boss rounds", () => {
+    expect(selectMusicTrack("PLAYER_TURN", 20, false)).toBe("music_boss");
+    expect(selectMusicTrack("PLAYER_TURN", 80, true)).toBe("music_boss");
+    expect(selectMusicTrack("BOSS_TURN", 80, false)).toBe("music_boss");
+  });
+
+  it("uses result-screen music", () => {
+    expect(selectMusicTrack("VICTORY", 80, false)).toBe("music_victory");
+    expect(selectMusicTrack("DEFEAT", 80, false)).toBe("music_defeat");
+  });
+});


### PR DESCRIPTION
## Summary

Adds adaptive music selection and SFX trigger points for gameplay, boss, victory, defeat, card play, block, damage, critical damage, and boss entrance.

## What Changed

- Expanded audio manifest for all planned music and SFX ids.
- Added `MusicDirector` with health/phase-based track selection.
- Wired music updates into the game loop.
- Wired SFX calls into card play, block, damage, critical damage, and boss entrance events.
- Added MusicDirector unit tests.

## Validation

- `npm test`
- `npm run build`
- Browser smoke path with no console errors.

Closes #15