### PR TITLE
F-14: Add recording mode and tune audio mix

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ npm run build
 - `Q/W/E/R/T`: damage compliance indicators
 - `A`: restore the lowest indicator
 
+For production video capture, append `?recording=1` to the live demo URL to enable the same shortcuts without changing the normal judge-facing URL.
+
 ## ElevenLabs Integration
 
 The game uses stable audio ids for:

--- a/src/audio/elevenlabs.ts
+++ b/src/audio/elevenlabs.ts
@@ -115,41 +115,41 @@ export const AUDIO_MANIFEST: AudioAsset[] = [
     id: "music_menu",
     type: "music",
     src: "/audio/music_menu.mp3",
-    volume: 0.15,
+    volume: 0.24,
     loop: true
   },
   {
     id: "music_gameplay_calm",
     type: "music",
     src: "/audio/music_gameplay_calm.mp3",
-    volume: 0.15,
+    volume: 0.2,
     loop: true
   },
   {
     id: "music_gameplay_tense",
     type: "music",
     src: "/audio/music_gameplay_tense.mp3",
-    volume: 0.15,
+    volume: 0.22,
     loop: true
   },
   {
     id: "music_boss",
     type: "music",
     src: "/audio/music_boss.mp3",
-    volume: 0.15,
+    volume: 0.24,
     loop: true
   },
   {
     id: "music_victory",
     type: "music",
     src: "/audio/music_victory.mp3",
-    volume: 0.15
+    volume: 0.24
   },
   {
     id: "music_defeat",
     type: "music",
     src: "/audio/music_defeat.mp3",
-    volume: 0.15
+    volume: 0.26
   },
   {
     id: "sfx_card_play",

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,6 +3,9 @@ export const TOTAL_ROUNDS = 15;
 export const CARD_TIMER_SECONDS = 15;
 export const DEV_MODE = import.meta.env.DEV;
 export const DEBUG_SKIP_AUDIO = import.meta.env.VITE_DEBUG_SKIP_AUDIO === "true";
+export const RECORDING_MODE = typeof window !== "undefined"
+  && new URLSearchParams(window.location.search).has("recording");
+export const ENABLE_QA_SHORTCUTS = DEV_MODE || RECORDING_MODE;
 
 export const INDICATORS = [
   "ictrisk",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import { AudioCache } from "./audio/audioCache";
 import { getAudioManifest } from "./audio/elevenlabs";
 import { selectMusicTrack, type MusicTrackId } from "./audio/MusicDirector";
-import { CARD_TIMER_SECONDS, COLORS, DEBUG_SKIP_AUDIO, DEV_MODE, GAME_TITLE, INDICATORS, TOTAL_ROUNDS } from "./config";
+import { CARD_TIMER_SECONDS, COLORS, DEBUG_SKIP_AUDIO, DEV_MODE, ENABLE_QA_SHORTCUTS, GAME_TITLE, INDICATORS, RECORDING_MODE, TOTAL_ROUNDS } from "./config";
 import { CardDeck } from "./game/CardDeck";
 import { ComplianceBoard, type Indicator } from "./game/ComplianceBoard";
 import { getDebugActionForKey } from "./game/DebugActions";
@@ -276,6 +276,14 @@ const render = (): void => {
       height - 16
     );
   }
+
+  if (RECORDING_MODE) {
+    context.fillStyle = COLORS.muted;
+    context.font = "12px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace";
+    context.textAlign = "right";
+    context.textBaseline = "bottom";
+    context.fillText("recording mode", width - 16, height - 16);
+  }
 };
 
 const update = (deltaSeconds: number): void => {
@@ -341,7 +349,7 @@ canvas.addEventListener("pointerdown", (event) => {
   resolveRound(cardId);
 });
 
-if (DEV_MODE) {
+if (ENABLE_QA_SHORTCUTS) {
   window.addEventListener("keydown", (event) => {
     const phaseKeys: Record<string, Phase> = {
       "0": "LOADING",


### PR DESCRIPTION
Closes #34

## Summary
- Add hidden production recording mode via ?recording=1 so video capture can use QA shortcuts on the deployed app.
- Keep the normal judge-facing URL unchanged.
- Raise music volumes modestly for phone playback while leaving dialogue at full volume.
- Document recording mode in README.

## Validation
- npm test
- npm run build
- Local recording-mode screenshot: /tmp/dora-recording-mode.png