### PR TITLE
F-15: Prevent overlapping gameplay audio

### DIFF
--- a/src/audio/audioCache.ts
+++ b/src/audio/audioCache.ts
@@ -13,14 +13,20 @@ type BrowserWindowWithWebkitAudio = Window & {
 export class AudioCache {
   private readonly assets: AudioAsset[];
   private readonly skipAudio: boolean;
+  private readonly assetsById = new Map<string, AudioAsset>();
   private readonly elements = new Map<string, HTMLAudioElement>();
   private readonly loadedIds = new Set<string>();
+  private activeDialogueId?: string;
+  private activeMusicId?: string;
+  private activeSfxId?: string;
+  private crossfadeId = 0;
   private unlocked = false;
   private audioContext?: AudioContext;
 
   constructor(assets: AudioAsset[], options: AudioCacheOptions = {}) {
     this.assets = assets;
     this.skipAudio = options.skipAudio ?? false;
+    this.assets.forEach((asset) => this.assetsById.set(asset.id, asset));
   }
 
   async load(onProgress?: ProgressHandler): Promise<void> {
@@ -88,7 +94,13 @@ export class AudioCache {
       return false;
     }
 
+    const asset = this.assetsById.get(id);
+    if (!asset) {
+      return false;
+    }
+
     if (this.skipAudio) {
+      this.markActive(asset);
       return true;
     }
 
@@ -97,8 +109,11 @@ export class AudioCache {
       return false;
     }
 
+    this.stopActiveForType(asset);
     element.currentTime = 0;
+    element.volume = asset.volume;
     void element.play();
+    this.markActive(asset);
     return true;
   }
 
@@ -116,21 +131,32 @@ export class AudioCache {
   crossfade(fromId: string, toId: string, durationMs: number): boolean {
     const from = this.elements.get(fromId);
     const to = this.elements.get(toId);
+    const fromAsset = this.assetsById.get(fromId);
+    const toAsset = this.assetsById.get(toId);
 
     if (this.skipAudio) {
       return this.play(toId);
     }
 
-    if (!from || !to || !this.unlocked) {
+    if (!from || !to || !fromAsset || !toAsset || !this.unlocked) {
       return false;
     }
 
+    this.crossfadeId += 1;
+    const activeCrossfadeId = this.crossfadeId;
+    this.stopOtherMusic(fromId, toId);
     const targetVolume = to.volume;
     const startedAt = performance.now();
     to.volume = 0;
+    to.currentTime = 0;
     void to.play();
+    this.activeMusicId = toId;
 
     const step = (now: number): void => {
+      if (activeCrossfadeId !== this.crossfadeId) {
+        return;
+      }
+
       const progress = Math.min(1, (now - startedAt) / Math.max(1, durationMs));
       from.volume = from.volume * (1 - progress);
       to.volume = targetVolume * progress;
@@ -142,10 +168,55 @@ export class AudioCache {
 
       from.pause();
       from.currentTime = 0;
+      from.volume = fromAsset.volume;
+      to.volume = toAsset.volume;
     };
 
     requestAnimationFrame(step);
     return true;
+  }
+
+  private markActive(asset: AudioAsset): void {
+    if (asset.type === "dialogue") {
+      this.activeDialogueId = asset.id;
+    }
+
+    if (asset.type === "music") {
+      this.activeMusicId = asset.id;
+    }
+
+    if (asset.type === "sfx") {
+      this.activeSfxId = asset.id;
+    }
+  }
+
+  private stopActiveForType(asset: AudioAsset): void {
+    if (asset.type === "dialogue") {
+      this.stopIfDifferent(this.activeDialogueId, asset.id);
+      return;
+    }
+
+    if (asset.type === "music") {
+      this.crossfadeId += 1;
+      this.stopIfDifferent(this.activeMusicId, asset.id);
+      return;
+    }
+
+    this.stopIfDifferent(this.activeSfxId, asset.id);
+  }
+
+  private stopIfDifferent(activeId: string | undefined, nextId: string): void {
+    if (activeId && activeId !== nextId) {
+      this.stop(activeId);
+    }
+  }
+
+  private stopOtherMusic(fromId: string, toId: string): void {
+    for (const asset of this.assets) {
+      if (asset.type === "music" && asset.id !== fromId && asset.id !== toId) {
+        this.stop(asset.id);
+      }
+    }
   }
 
   private loadElement(asset: AudioAsset): Promise<void> {

--- a/tests/AudioCache.test.ts
+++ b/tests/AudioCache.test.ts
@@ -4,13 +4,73 @@ import type { AudioAsset } from "../src/audio/elevenlabs";
 
 const assets: AudioAsset[] = [
   { id: "dialogue_test", type: "dialogue", src: "/audio/dialogue_test.mp3", volume: 1 },
+  { id: "dialogue_second", type: "dialogue", src: "/audio/dialogue_second.mp3", volume: 1 },
   { id: "music_menu", type: "music", src: "/audio/music_menu.mp3", volume: 0.15, loop: true },
+  { id: "music_boss", type: "music", src: "/audio/music_boss.mp3", volume: 0.2, loop: true },
+  { id: "sfx_damage", type: "sfx", src: "/audio/sfx_damage.mp3", volume: 0.6 },
   { id: "sfx_card_play", type: "sfx", src: "/audio/sfx_card_play.mp3", volume: 0.6 }
 ];
+
+class FakeAudioElement {
+  static instances = new Map<string, FakeAudioElement>();
+
+  currentTime = 0;
+  loop = false;
+  preload = "";
+  volume = 1;
+  play = vi.fn(() => Promise.resolve());
+  pause = vi.fn();
+  private listeners = new Map<string, () => void>();
+
+  constructor(readonly src: string) {
+    FakeAudioElement.instances.set(src, this);
+  }
+
+  addEventListener(event: string, listener: () => void): void {
+    this.listeners.set(event, listener);
+  }
+
+  load(): void {
+    this.listeners.get("canplaythrough")?.();
+  }
+}
+
+class FakeAudioContext {
+  destination = {};
+
+  async resume(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  createBuffer(): AudioBuffer {
+    return {} as AudioBuffer;
+  }
+
+  createBufferSource(): AudioBufferSourceNode {
+    return {
+      buffer: null,
+      connect: vi.fn(),
+      start: vi.fn()
+    } as unknown as AudioBufferSourceNode;
+  }
+}
+
+const setupRealAudioCache = async (): Promise<AudioCache> => {
+  FakeAudioElement.instances.clear();
+  vi.stubGlobal("Audio", FakeAudioElement);
+  vi.stubGlobal("window", { AudioContext: FakeAudioContext });
+
+  const cache = new AudioCache(assets);
+  await cache.load();
+  await cache.unlock();
+
+  return cache;
+};
 
 describe("AudioCache", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
+    vi.restoreAllMocks();
   });
 
   it("reports progress while loading in skip-audio mode", async () => {
@@ -22,7 +82,8 @@ describe("AudioCache", () => {
     });
 
     expect(cache.getProgress()).toBe(1);
-    expect(progress).toEqual([1 / 3, 2 / 3, 1]);
+    expect(progress).toHaveLength(assets.length);
+    expect(progress.at(-1)).toBe(1);
   });
 
   it("will not play before browser audio is unlocked", async () => {
@@ -34,26 +95,6 @@ describe("AudioCache", () => {
   });
 
   it("plays loaded assets after audio is unlocked", async () => {
-    class FakeAudioContext {
-      destination = {};
-
-      async resume(): Promise<void> {
-        return Promise.resolve();
-      }
-
-      createBuffer(): AudioBuffer {
-        return {} as AudioBuffer;
-      }
-
-      createBufferSource(): AudioBufferSourceNode {
-        return {
-          buffer: null,
-          connect: vi.fn(),
-          start: vi.fn()
-        } as unknown as AudioBufferSourceNode;
-      }
-    }
-
     vi.stubGlobal("window", { AudioContext: FakeAudioContext });
     const cache = new AudioCache(assets, { skipAudio: true });
 
@@ -70,5 +111,44 @@ describe("AudioCache", () => {
     await cache.load();
 
     expect(cache.getProgress()).toBe(1);
+  });
+
+  it("stops previous dialogue before playing the next dialogue", async () => {
+    const cache = await setupRealAudioCache();
+    const first = FakeAudioElement.instances.get("/audio/dialogue_test.mp3");
+    const second = FakeAudioElement.instances.get("/audio/dialogue_second.mp3");
+
+    expect(cache.play("dialogue_test")).toBe(true);
+    expect(cache.play("dialogue_second")).toBe(true);
+
+    expect(first?.pause).toHaveBeenCalledTimes(1);
+    expect(first?.currentTime).toBe(0);
+    expect(second?.play).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops previous sfx before playing the next sfx", async () => {
+    const cache = await setupRealAudioCache();
+    const first = FakeAudioElement.instances.get("/audio/sfx_card_play.mp3");
+    const second = FakeAudioElement.instances.get("/audio/sfx_damage.mp3");
+
+    expect(cache.play("sfx_card_play")).toBe(true);
+    expect(cache.play("sfx_damage")).toBe(true);
+
+    expect(first?.pause).toHaveBeenCalledTimes(1);
+    expect(first?.currentTime).toBe(0);
+    expect(second?.play).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps only one direct music track active at a time", async () => {
+    const cache = await setupRealAudioCache();
+    const first = FakeAudioElement.instances.get("/audio/music_menu.mp3");
+    const second = FakeAudioElement.instances.get("/audio/music_boss.mp3");
+
+    expect(cache.play("music_menu")).toBe(true);
+    expect(cache.play("music_boss")).toBe(true);
+
+    expect(first?.pause).toHaveBeenCalledTimes(1);
+    expect(first?.currentTime).toBe(0);
+    expect(second?.play).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
Closes #36

## Summary
- Add AudioCache channel ownership for dialogue, SFX, and music.
- Stop previous dialogue before a new voice line plays.
- Stop previous SFX before a new SFX plays.
- Cancel stale music crossfades and prevent multiple music tracks from staying active.
- Add fake-audio tests for overlap prevention.

## Validation
- npm test
- npm run build