### PR TITLE
F-16: Add polished cover social image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # DORA: The Compliance Roguelike
 
+![DORA: The Compliance Roguelike cover](public/cover-social.svg)
+
 Survive the audit. Save the FinTech.
 
 A browser-based card roguelike where you play as a FinTech CTO defending against EU regulatory audit findings. The Regulator is designed around pre-generated ElevenLabs TTS, adaptive music, and audit findings that escalate into a Grand Regulator boss phase.

--- a/public/cover-social.svg
+++ b/public/cover-social.svg
@@ -1,0 +1,64 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-labelledby="title desc">
+  <title id="title">DORA: The Compliance Roguelike cover image</title>
+  <desc id="desc">A dark institutional audit cover image featuring the Regulator, a ten million euro fine, and the tagline Survive the audit.</desc>
+  <defs>
+    <linearGradient id="background" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0d0d1a"/>
+      <stop offset="0.58" stop-color="#111827"/>
+      <stop offset="1" stop-color="#1a1a2e"/>
+    </linearGradient>
+    <linearGradient id="notice" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#2b1220"/>
+      <stop offset="1" stop-color="#1a1a2e"/>
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="18" stdDeviation="18" flood-color="#000000" flood-opacity="0.45"/>
+    </filter>
+  </defs>
+
+  <rect width="1200" height="630" fill="url(#background)"/>
+  <path d="M0 88H1200" stroke="#24344d" stroke-width="2"/>
+  <path d="M0 542H1200" stroke="#24344d" stroke-width="2"/>
+
+  <g opacity="0.22" fill="none" stroke="#4a90e2" stroke-width="1">
+    <path d="M84 128H514M84 168H430M84 208H482M84 248H356"/>
+    <path d="M846 124H1092M846 164H1036M846 204H1100M846 244H984"/>
+    <rect x="72" y="108" width="478" height="176" rx="4"/>
+    <rect x="828" y="104" width="296" height="174" rx="4"/>
+  </g>
+
+  <g transform="translate(828 342) scale(0.82)" filter="url(#shadow)">
+    <ellipse cx="0" cy="-150" rx="54" ry="58" fill="#0b1020" stroke="#4a90e2" stroke-width="5"/>
+    <path d="M-82 -82H82L116 146H-116Z" fill="#101827" stroke="#4a90e2" stroke-width="5"/>
+    <path d="M0 -56L24 54L0 92L-24 54Z" fill="#c0392b"/>
+    <path d="M68 -96L154 80H108L44 -84Z" fill="#0c1425" stroke="#4a90e2" stroke-width="4"/>
+    <rect x="112" y="36" width="116" height="86" rx="8" fill="#111827" stroke="#e67e22" stroke-width="5"/>
+    <rect x="142" y="20" width="54" height="24" rx="10" fill="none" stroke="#e67e22" stroke-width="5"/>
+    <circle cx="54" cy="-54" r="11" fill="#4a90e2"/>
+    <circle cx="54" cy="-54" r="4" fill="#e67e22"/>
+  </g>
+
+  <g transform="translate(78 96)">
+    <text x="0" y="38" fill="#8fa3b8" font-family="Inter, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="24" font-weight="800" letter-spacing="3">ELEVENLABS VOICED BOSS FIGHT</text>
+    <text x="0" y="124" fill="#ecf0f1" font-family="Inter, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="82" font-weight="900">DORA</text>
+    <text x="0" y="184" fill="#ecf0f1" font-family="Inter, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="46" font-weight="900">The Compliance Roguelike</text>
+    <text x="0" y="252" fill="#4a90e2" font-family="Inter, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="34" font-weight="800">Survive the audit. Save the FinTech.</text>
+  </g>
+
+  <g transform="translate(78 402)" filter="url(#shadow)">
+    <rect width="506" height="128" rx="8" fill="url(#notice)" stroke="#c0392b" stroke-width="4"/>
+    <text x="32" y="48" fill="#8fa3b8" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="22" font-weight="800">ENFORCEMENT NOTICE</text>
+    <text x="32" y="100" fill="#ecf0f1" font-family="Inter, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="46" font-weight="900">EUR 10,000,000 FINE</text>
+  </g>
+
+  <g transform="translate(838 456)" fill="#4a90e2">
+    <rect x="0" y="34" width="14" height="44" rx="4"/>
+    <rect x="24" y="12" width="14" height="88" rx="4"/>
+    <rect x="48" y="26" width="14" height="60" rx="4"/>
+    <rect x="72" y="0" width="14" height="110" rx="4"/>
+    <rect x="96" y="20" width="14" height="72" rx="4"/>
+    <rect x="120" y="42" width="14" height="38" rx="4"/>
+  </g>
+
+  <text x="78" y="584" fill="#8fa3b8" font-family="Inter, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="22" font-weight="700">Built for ElevenHacks Hack #6 - Zed x ElevenLabs</text>
+</svg>

--- a/tests/SubmissionAssets.test.ts
+++ b/tests/SubmissionAssets.test.ts
@@ -1,0 +1,14 @@
+import { existsSync, readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("submission assets", () => {
+  it("includes a social cover image with the project and fine hook", () => {
+    const coverPath = "public/cover-social.svg";
+    const cover = readFileSync(coverPath, "utf8");
+
+    expect(existsSync(coverPath)).toBe(true);
+    expect(cover).toContain("DORA");
+    expect(cover).toContain("EUR 10,000,000 FINE");
+    expect(cover).toContain("ElevenLabs");
+  });
+});


### PR DESCRIPTION
Closes #38

## Summary
- Add a 1200x630 social cover SVG with the DORA title, ElevenLabs hook, and EUR 10,000,000 fine notice.
- Display the cover image at the top of README.
- Add a submission asset test to protect the cover hook.

## Validation
- npm test
- npm run build
- Rendered cover preview: /tmp/cover-social.svg.png