### PR TITLE
[F-19] Add NIS2 defense cards

### DIFF
--- a/src/game/CardDeck.ts
+++ b/src/game/CardDeck.ts
@@ -224,8 +224,110 @@ const createCards = (): Card[] => [
     citation: "DORA Article 6",
     description: "Restore Reporting by 35%.",
     flavour: "A dashboard that says both less and more than anyone hoped."
+  },
+  {
+    id: "nis2-risk-analysis",
+    name: "NIS2 Risk Analysis",
+    type: "shield",
+    target: "ictrisk",
+    effect: { kind: "block" },
+    citation: "NIS2 Article 21(2)(a)",
+    description: "Block an ICT Risk governance attack.",
+    flavour: "A risk register with fewer vibes and more owners."
+  },
+  {
+    id: "nis2-incident-handling",
+    name: "NIS2 Incident Handling",
+    type: "shield",
+    target: "incidents",
+    effect: { kind: "block" },
+    citation: "NIS2 Article 21(2)(b)",
+    description: "Block an Incident Response attack.",
+    flavour: "Everyone knows the bridge link. A rare luxury."
+  },
+  {
+    id: "nis2-business-continuity",
+    name: "NIS2 Continuity Plan",
+    type: "restore",
+    target: "testing",
+    effect: { kind: "restore", amount: 45 },
+    citation: "NIS2 Article 21(2)(c)",
+    description: "Restore Testing by 45%.",
+    flavour: "The restore test finally restored something other than confidence."
+  },
+  {
+    id: "nis2-supply-chain",
+    name: "NIS2 Supply Chain Review",
+    type: "shield",
+    target: "thirdparty",
+    effect: { kind: "block" },
+    citation: "NIS2 Article 21(2)(d)",
+    description: "Block a Third-Party attack.",
+    flavour: "Your vendor's vendor has entered the chat."
+  },
+  {
+    id: "nis2-secure-development",
+    name: "NIS2 Secure Development",
+    type: "restore",
+    target: "ictrisk",
+    effect: { kind: "restore", amount: 35 },
+    citation: "NIS2 Article 21(2)(e)",
+    description: "Restore ICT Risk by 35%.",
+    flavour: "The pull request now includes threat modeling. Somehow."
+  },
+  {
+    id: "nis2-effectiveness-testing",
+    name: "NIS2 Effectiveness Testing",
+    type: "shield",
+    target: "testing",
+    effect: { kind: "block" },
+    citation: "NIS2 Article 21(2)(f)",
+    description: "Block a Testing attack.",
+    flavour: "A control test with evidence. The auditor briefly smiles."
+  },
+  {
+    id: "nis2-cyber-hygiene",
+    name: "NIS2 Cyber Hygiene",
+    type: "restore",
+    target: "incidents",
+    effect: { kind: "restore", amount: 35 },
+    citation: "NIS2 Article 21(2)(g)",
+    description: "Restore Incidents by 35%.",
+    flavour: "Security training, but the quiz finally learned shame."
+  },
+  {
+    id: "nis2-cryptography",
+    name: "NIS2 Cryptography",
+    type: "shield",
+    target: "reporting",
+    effect: { kind: "block" },
+    citation: "NIS2 Article 21(2)(h)",
+    description: "Block a Reporting or evidence attack.",
+    flavour: "Encrypted, logged, and blessed by key rotation."
+  },
+  {
+    id: "nis2-access-control",
+    name: "NIS2 Access Control",
+    type: "shield",
+    target: "ictrisk",
+    effect: { kind: "block" },
+    citation: "NIS2 Article 21(2)(i)",
+    description: "Block an access-control attack.",
+    flavour: "Least privilege: beloved in policy, feared in Slack."
+  },
+  {
+    id: "nis2-mfa-secure-comms",
+    name: "NIS2 MFA + Secure Comms",
+    type: "shield",
+    target: "incidents-testing",
+    effect: { kind: "block" },
+    citation: "NIS2 Article 21(2)(j)",
+    description: "Block Incident or Testing attacks.",
+    flavour: "MFA fatigue meets secure communications. Nobody wins, but everyone logs in."
   }
 ];
+
+export const getCardDefinitions = (): Card[] => createCards();
 
 export class CardDeck {
   private readonly random: () => number;

--- a/tests/CardDeck.test.ts
+++ b/tests/CardDeck.test.ts
@@ -1,17 +1,17 @@
 import { describe, expect, it } from "vitest";
-import { CardDeck } from "../src/game/CardDeck";
+import { CardDeck, getCardDefinitions } from "../src/game/CardDeck";
 
 const predictableRandom = (): number => 0;
 
 describe("CardDeck", () => {
-  it("contains a 20-card deck and draws an opening hand of 5", () => {
+  it("contains a 30-card deck and draws an opening hand of 5", () => {
     const deck = new CardDeck(predictableRandom);
 
     const hand = deck.draw(5);
 
     expect(hand).toHaveLength(5);
     expect(deck.getHand()).toHaveLength(5);
-    expect(deck.getDrawPileCount()).toBe(15);
+    expect(deck.getDrawPileCount()).toBe(25);
   });
 
   it("plays a card from hand into discard", () => {
@@ -40,7 +40,7 @@ describe("CardDeck", () => {
 
   it("Legal Counsel counters any attack", () => {
     const deck = new CardDeck(predictableRandom);
-    deck.draw(20);
+    deck.draw(30);
     const counsel = deck.getHand().find((card) => card.id === "legal-counsel");
 
     expect(counsel).toBeDefined();
@@ -52,7 +52,7 @@ describe("CardDeck", () => {
 
   it("Coffee Break does not counter attacks", () => {
     const deck = new CardDeck(predictableRandom);
-    deck.draw(20);
+    deck.draw(30);
     const coffee = deck.getHand().find((card) => card.id === "coffee-break");
 
     expect(coffee).toBeDefined();
@@ -60,5 +60,35 @@ describe("CardDeck", () => {
       type: "any",
       targets: ["ictrisk"]
     })).toBe(false);
+  });
+
+  it("adds one NIS2 Article 21 card for each mandatory control family", () => {
+    const nis2Cards = getCardDefinitions().filter((card) => card.id.startsWith("nis2-"));
+
+    expect(nis2Cards).toHaveLength(11);
+    expect(nis2Cards.map((card) => card.citation)).toEqual(expect.arrayContaining([
+      "NIS2 Article 21",
+      "NIS2 Article 21(2)(a)",
+      "NIS2 Article 21(2)(b)",
+      "NIS2 Article 21(2)(c)",
+      "NIS2 Article 21(2)(d)",
+      "NIS2 Article 21(2)(e)",
+      "NIS2 Article 21(2)(f)",
+      "NIS2 Article 21(2)(g)",
+      "NIS2 Article 21(2)(h)",
+      "NIS2 Article 21(2)(i)",
+      "NIS2 Article 21(2)(j)"
+    ]));
+  });
+
+  it("NIS2 MFA and secure communications card counters incident or testing attacks", () => {
+    const mfaCard = getCardDefinitions().find((card) => card.id === "nis2-mfa-secure-comms");
+    const deck = new CardDeck(predictableRandom);
+
+    expect(mfaCard).toBeDefined();
+    expect(deck.doesCardCounter(mfaCard!, {
+      type: "security",
+      targets: ["testing"]
+    })).toBe(true);
   });
 });


### PR DESCRIPTION
Closes #19

## Summary
- Expand the deck from 20 to 30 cards.
- Add ten NIS2 Article 21 control-family defense cards.
- Keep the original general NIS2 Barrier card.
- Add tests for the expanded deck and NIS2 card coverage.

## Validation
- npm test
- npm run build