### PR TITLE
[F-22] Add co-op audit views

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ For Dutch regulator mode, append `?locale=nl` to the live demo URL.
 
 For the optional GDPR Data Protection Authority boss, append `?boss=gdpr`.
 
+For two-player audit mode, open two windows:
+
+- Player 1 card hand: `?mode=coop&role=cards`
+- Player 2 board and regulator intent: `?mode=coop&role=board`
+
 ## ElevenLabs Integration
 
 The game uses stable audio ids for:

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,5 @@
+import { parseCoopView } from "./game/CoopMode";
+
 export const GAME_TITLE = "DORA: The Compliance Roguelike";
 export const TOTAL_ROUNDS = 15;
 export const CARD_TIMER_SECONDS = 15;
@@ -16,6 +18,7 @@ export const BOSS_MODE: BossMode = typeof window !== "undefined"
   && new URLSearchParams(window.location.search).get("boss") === "gdpr"
   ? "gdpr"
   : "dora";
+export const COOP_VIEW = parseCoopView(typeof window !== "undefined" ? window.location.search : "");
 
 export const INDICATORS = [
   "ictrisk",

--- a/src/game/CoopMode.ts
+++ b/src/game/CoopMode.ts
@@ -1,0 +1,48 @@
+export type GameMode = "solo" | "coop";
+export type CoopRole = "combined" | "cards" | "board";
+
+export interface CoopView {
+  mode: GameMode;
+  role: CoopRole;
+}
+
+export const parseCoopView = (search: string): CoopView => {
+  const params = new URLSearchParams(search);
+  const mode: GameMode = params.get("mode") === "coop" ? "coop" : "solo";
+
+  if (mode === "solo") {
+    return { mode, role: "combined" };
+  }
+
+  const role = params.get("role");
+
+  if (role === "cards" || role === "board") {
+    return { mode, role };
+  }
+
+  return { mode, role: "combined" };
+};
+
+export const shouldShowCards = (view: CoopView): boolean => {
+  return view.role !== "board";
+};
+
+export const shouldShowAuditIntel = (view: CoopView): boolean => {
+  return view.role !== "cards";
+};
+
+export const getCoopRoleLabel = (view: CoopView): string => {
+  if (view.mode === "solo") {
+    return "";
+  }
+
+  if (view.role === "cards") {
+    return "CO-OP PLAYER 1: CARD HAND";
+  }
+
+  if (view.role === "board") {
+    return "CO-OP PLAYER 2: BOARD + REGULATOR INTENT";
+  }
+
+  return "CO-OP COMBINED VIEW";
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,11 @@
 import { AudioCache } from "./audio/audioCache";
 import { getAudioManifest } from "./audio/elevenlabs";
 import { selectMusicTrack, type MusicTrackId } from "./audio/MusicDirector";
-import { BOSS_MODE, CARD_TIMER_SECONDS, COLORS, DEBUG_SKIP_AUDIO, DEV_MODE, ENABLE_QA_SHORTCUTS, GAME_LOCALE, GAME_TITLE, INDICATORS, RECORDING_MODE, TOTAL_ROUNDS } from "./config";
+import { BOSS_MODE, CARD_TIMER_SECONDS, COLORS, COOP_VIEW, DEBUG_SKIP_AUDIO, DEV_MODE, ENABLE_QA_SHORTCUTS, GAME_LOCALE, GAME_TITLE, INDICATORS, RECORDING_MODE, TOTAL_ROUNDS } from "./config";
 import { CardDeck } from "./game/CardDeck";
 import { ComplianceBoard, type Indicator } from "./game/ComplianceBoard";
 import { getDebugActionForKey } from "./game/DebugActions";
+import { getCoopRoleLabel, shouldShowAuditIntel, shouldShowCards } from "./game/CoopMode";
 import { GameState, type Phase } from "./game/GameState";
 import { RegulatorAI, type Attack } from "./game/RegulatorAI";
 import { TurnTimer } from "./game/TurnTimer";
@@ -66,6 +67,20 @@ const updateMusic = (): void => {
   }
 
   currentMusic = nextMusic;
+};
+
+const renderCoopRoleBanner = (width: number, y: number): void => {
+  const label = getCoopRoleLabel(COOP_VIEW);
+
+  if (!label) {
+    return;
+  }
+
+  context.fillStyle = COLORS.warnAmber;
+  context.font = "700 12px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace";
+  context.textAlign = "center";
+  context.textBaseline = "middle";
+  context.fillText(label, width / 2, y, Math.max(260, width - 48));
 };
 
 const startRound = (round: number): void => {
@@ -196,19 +211,28 @@ const render = (): void => {
 
   if (phase === "MENU") {
     renderMenuScene(context, width, height);
-    renderComplianceBoard(context, complianceBoard.getAll(), {
-      x: Math.max(16, width * 0.08),
-      y: height * 0.56,
-      width: Math.min(560, width - 32),
-      now: performance.now()
-    });
-    cardHitBoxes = renderCards(context, cardDeck.getHand(), {
-      x: 16,
-      y: Math.max(height - 156, height * 0.76),
-      width: width - 32,
-      height: 136,
-      pointer
-    });
+    renderCoopRoleBanner(width, height * 0.62);
+
+    if (shouldShowAuditIntel(COOP_VIEW)) {
+      renderComplianceBoard(context, complianceBoard.getAll(), {
+        x: Math.max(16, width * 0.08),
+        y: height * 0.56,
+        width: Math.min(560, width - 32),
+        now: performance.now()
+      });
+    }
+
+    if (shouldShowCards(COOP_VIEW)) {
+      cardHitBoxes = renderCards(context, cardDeck.getHand(), {
+        x: 16,
+        y: Math.max(height - 156, height * 0.76),
+        width: width - 32,
+        height: 136,
+        pointer
+      });
+    } else {
+      cardHitBoxes = [];
+    }
     return;
   }
 
@@ -221,22 +245,31 @@ const render = (): void => {
   context.fillRect(0, 0, width, height);
 
   if ((phase === "PLAYER_TURN" || phase === "BOSS_TURN") && currentAttack) {
-    renderGameScene(context, width, currentAttack, regulatorAI.getText(currentAttack, GAME_LOCALE), currentReaction);
-    renderRegulator(context, width - 112, 190, currentAttack.voice, true, performance.now());
-    renderTurnTimer(context, width, turnTimer.getRemainingSeconds());
-    renderComplianceBoard(context, complianceBoard.getAll(), {
-      x: Math.max(16, width * 0.08),
-      y: 210,
-      width: Math.min(560, width - 32),
-      now: performance.now()
-    });
-    cardHitBoxes = renderCards(context, cardDeck.getHand(), {
-      x: 16,
-      y: Math.max(height - 156, height * 0.76),
-      width: width - 32,
-      height: 136,
-      pointer
-    });
+    if (shouldShowAuditIntel(COOP_VIEW)) {
+      renderGameScene(context, width, currentAttack, regulatorAI.getText(currentAttack, GAME_LOCALE), currentReaction);
+      renderRegulator(context, width - 112, 190, currentAttack.voice, true, performance.now());
+      renderComplianceBoard(context, complianceBoard.getAll(), {
+        x: Math.max(16, width * 0.08),
+        y: 210,
+        width: Math.min(560, width - 32),
+        now: performance.now()
+      });
+    }
+
+    renderCoopRoleBanner(width, shouldShowAuditIntel(COOP_VIEW) ? 188 : 96);
+
+    if (shouldShowCards(COOP_VIEW)) {
+      renderTurnTimer(context, width, turnTimer.getRemainingSeconds());
+      cardHitBoxes = renderCards(context, cardDeck.getHand(), {
+        x: 16,
+        y: Math.max(height - 156, height * 0.76),
+        width: width - 32,
+        height: 136,
+        pointer
+      });
+    } else {
+      cardHitBoxes = [];
+    }
     return;
   }
 
@@ -336,6 +369,10 @@ canvas.addEventListener("pointerdown", (event) => {
   }
 
   if (gameState.getPhase() !== "PLAYER_TURN" && gameState.getPhase() !== "BOSS_TURN") {
+    return;
+  }
+
+  if (!shouldShowCards(COOP_VIEW)) {
     return;
   }
 

--- a/tests/CoopMode.test.ts
+++ b/tests/CoopMode.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { getCoopRoleLabel, parseCoopView, shouldShowAuditIntel, shouldShowCards } from "../src/game/CoopMode";
+
+describe("CoopMode", () => {
+  it("defaults to a solo combined view", () => {
+    const view = parseCoopView("");
+
+    expect(view).toEqual({ mode: "solo", role: "combined" });
+    expect(shouldShowCards(view)).toBe(true);
+    expect(shouldShowAuditIntel(view)).toBe(true);
+  });
+
+  it("supports a card-hand role for player one", () => {
+    const view = parseCoopView("?mode=coop&role=cards");
+
+    expect(shouldShowCards(view)).toBe(true);
+    expect(shouldShowAuditIntel(view)).toBe(false);
+    expect(getCoopRoleLabel(view)).toContain("PLAYER 1");
+  });
+
+  it("supports a board and regulator intent role for player two", () => {
+    const view = parseCoopView("?mode=coop&role=board");
+
+    expect(shouldShowCards(view)).toBe(false);
+    expect(shouldShowAuditIntel(view)).toBe(true);
+    expect(getCoopRoleLabel(view)).toContain("PLAYER 2");
+  });
+});


### PR DESCRIPTION
Closes #22

## Summary
- Add two-player co-op view parsing for ?mode=coop.
- Add role-specific views: ?mode=coop&role=cards and ?mode=coop&role=board.
- Hide audit intel from the card role and hide card controls from the board role.
- Document the two-window setup in README.
- Add focused co-op mode tests.

## Validation
- npm test
- npm run build